### PR TITLE
[FEAT] 조회수 기능 추가

### DIFF
--- a/src/main/java/com/danum/danum/controller/board/QuestionController.java
+++ b/src/main/java/com/danum/danum/controller/board/QuestionController.java
@@ -4,6 +4,8 @@ import com.danum.danum.domain.board.question.QuestionNewDto;
 import com.danum.danum.service.board.question.QuestionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -32,8 +34,14 @@ public class QuestionController {
     }
 
     @GetMapping("/show/{id}")
-    public ResponseEntity<?> getQuestionBoardById(@PathVariable("id") Long id, @RequestParam(value = "email", required = true) String email){
-        return ResponseEntity.ok(questionService.view(id, email));
+    public ResponseEntity<?> getQuestionBoardById(@PathVariable("id") Long id){
+        return ResponseEntity.ok(questionService.view(id, getLoginUser()));
+    }
+
+    private String getLoginUser(){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        return authentication.getName();
     }
 
 }

--- a/src/main/java/com/danum/danum/controller/board/VillageController.java
+++ b/src/main/java/com/danum/danum/controller/board/VillageController.java
@@ -4,11 +4,14 @@ import com.danum.danum.domain.board.village.VillageNewDto;
 import com.danum.danum.service.board.village.VillageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -32,7 +35,13 @@ public class VillageController {
 
     @GetMapping("/show/{id}")
     public ResponseEntity<?> getVillageBoardById(@PathVariable("id") Long id){
-        return ResponseEntity.ok(villageService.view(id));
+        return ResponseEntity.ok(villageService.view(id, getLoginUser()));
+    }
+
+    private String getLoginUser(){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        return authentication.getName();
     }
 
 }

--- a/src/main/java/com/danum/danum/domain/board/question/Question.java
+++ b/src/main/java/com/danum/danum/domain/board/question/Question.java
@@ -52,10 +52,10 @@ public class Question {
     private Long like;
 
     @Column(name = "question_count")
-    private Long count;
+    private Long view_count;
 
-    public void addCount() {
-        this.count++;
+    public void increasedViews() {
+        this.view_count++;
     }
 
 }

--- a/src/main/java/com/danum/danum/domain/board/question/QuestionEmailToken.java
+++ b/src/main/java/com/danum/danum/domain/board/question/QuestionEmailToken.java
@@ -16,7 +16,7 @@ import org.springframework.data.redis.core.index.Indexed;
 public class QuestionEmailToken {
 
     @Id
-    private String id;
+    private Long id;
 
     @Indexed
     private String email;

--- a/src/main/java/com/danum/danum/domain/board/question/QuestionMapper.java
+++ b/src/main/java/com/danum/danum/domain/board/question/QuestionMapper.java
@@ -37,7 +37,7 @@ public class QuestionMapper {
                 .content(questionNewDto.getContent())
                 .created_at(LocalDateTime.now())
                 .like(0L)
-                .count(0L);
+                .view_count(0L);
 
         if(questionNewDto.getCreateId() != null) {
             OpenAiConversation conversation = conversationRepository.findById(questionNewDto.getCreateId())

--- a/src/main/java/com/danum/danum/domain/board/question/QuestionViewDto.java
+++ b/src/main/java/com/danum/danum/domain/board/question/QuestionViewDto.java
@@ -26,6 +26,8 @@ public class QuestionViewDto {
 
     private OpenAiConversation conversation;
 
+    private Long view_count;
+
     public static QuestionViewDto from(Question question) {
         return QuestionViewDto.builder()
                 .question_id(question.getId())
@@ -34,6 +36,7 @@ public class QuestionViewDto {
                 .content(question.getContent())
                 .created_at(question.getCreated_at())
                 .conversation(question.getConversation())
+                .view_count(question.getView_count())
                 .build();
     }
 

--- a/src/main/java/com/danum/danum/domain/board/village/Village.java
+++ b/src/main/java/com/danum/danum/domain/board/village/Village.java
@@ -47,18 +47,10 @@ public class Village {
     private Long like;
 
     @Column(name = "village_count")
-    private Long count;
+    private Long view_count;
 
-    public void addView() {
-        this.count += 1L;
-    }
-
-    public void addLike() {
-        this.like += 1;
-    }
-
-    public void subLike() {
-        this.like -= 1;
+    public void increasedViews() {
+        this.view_count++;
     }
 
 }

--- a/src/main/java/com/danum/danum/domain/board/village/VillageEmailToken.java
+++ b/src/main/java/com/danum/danum/domain/board/village/VillageEmailToken.java
@@ -16,7 +16,7 @@ import org.springframework.data.redis.core.index.Indexed;
 public class VillageEmailToken {
 
     @Id
-    private String id;
+    private Long id;
 
     @Indexed
     private String email;

--- a/src/main/java/com/danum/danum/domain/board/village/VillageEmailToken.java
+++ b/src/main/java/com/danum/danum/domain/board/village/VillageEmailToken.java
@@ -1,0 +1,24 @@
+package com.danum.danum.domain.board.village;
+
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@RedisHash(value = "villageEmail", timeToLive = 86400)
+public class VillageEmailToken {
+
+    @Id
+    private String id;
+
+    @Indexed
+    private String email;
+
+}

--- a/src/main/java/com/danum/danum/domain/board/village/VillageMapper.java
+++ b/src/main/java/com/danum/danum/domain/board/village/VillageMapper.java
@@ -32,7 +32,7 @@ public class VillageMapper {
                 .content(villageNewDto.getContent())
                 .created_at(LocalDateTime.now())
                 .like(0L)
-                .count(0L).build();
+                .view_count(0L).build();
     }
 
 }

--- a/src/main/java/com/danum/danum/domain/board/village/VillageViewDto.java
+++ b/src/main/java/com/danum/danum/domain/board/village/VillageViewDto.java
@@ -23,6 +23,8 @@ public class VillageViewDto {
 
     private LocalDateTime created_at;
 
+    private Long view_count;
+
     public VillageViewDto toEntity(Village village) {
         return VillageViewDto.builder()
                 .village_id(village.getId())
@@ -30,6 +32,7 @@ public class VillageViewDto {
                 .title(village.getTitle())
                 .content(village.getContent())
                 .created_at(village.getCreated_at())
+                .view_count(village.getView_count())
                 .build();
     }
 

--- a/src/main/java/com/danum/danum/repository/QuestionEmailRepository.java
+++ b/src/main/java/com/danum/danum/repository/QuestionEmailRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface QuestionEmailRepository extends CrudRepository<QuestionEmailToken, String> {
+public interface QuestionEmailRepository extends CrudRepository<QuestionEmailToken, Long> {
 }

--- a/src/main/java/com/danum/danum/repository/VillageEmailRepository.java
+++ b/src/main/java/com/danum/danum/repository/VillageEmailRepository.java
@@ -1,0 +1,7 @@
+package com.danum.danum.repository;
+
+import com.danum.danum.domain.board.village.VillageEmailToken;
+import org.springframework.data.repository.CrudRepository;
+
+public interface VillageEmailRepository extends CrudRepository<VillageEmailToken, String> {
+}

--- a/src/main/java/com/danum/danum/repository/VillageEmailRepository.java
+++ b/src/main/java/com/danum/danum/repository/VillageEmailRepository.java
@@ -3,5 +3,5 @@ package com.danum.danum.repository;
 import com.danum.danum.domain.board.village.VillageEmailToken;
 import org.springframework.data.repository.CrudRepository;
 
-public interface VillageEmailRepository extends CrudRepository<VillageEmailToken, String> {
+public interface VillageEmailRepository extends CrudRepository<VillageEmailToken, Long> {
 }

--- a/src/main/java/com/danum/danum/service/board/question/QuestionServiceImpl.java
+++ b/src/main/java/com/danum/danum/service/board/question/QuestionServiceImpl.java
@@ -5,6 +5,7 @@ import com.danum.danum.domain.board.question.QuestionEmailToken;
 import com.danum.danum.domain.board.question.QuestionMapper;
 import com.danum.danum.domain.board.question.QuestionNewDto;
 import com.danum.danum.domain.board.question.QuestionViewDto;
+import com.danum.danum.domain.board.village.VillageEmailToken;
 import com.danum.danum.exception.custom.BoardException;
 import com.danum.danum.exception.ErrorCode;
 import com.danum.danum.exception.custom.MemberException;
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -61,11 +63,13 @@ public class QuestionServiceImpl implements QuestionService{
     }
 
     private void viewCheck(Question question, String email) {
-        if (questionEmailRepository.existsById(email)) {
+        Optional<QuestionEmailToken> optionalQuestionEmailToken = questionEmailRepository.findById(question.getId());
+        if (optionalQuestionEmailToken.isPresent() && optionalQuestionEmailToken.get().getEmail().equals(email)) {
             return;
         }
+        
         QuestionEmailToken token = QuestionEmailToken.builder()
-                .id(email)
+                .id(question.getId())
                 .email(email)
                 .build();
         question.increasedViews();

--- a/src/main/java/com/danum/danum/service/board/question/QuestionServiceImpl.java
+++ b/src/main/java/com/danum/danum/service/board/question/QuestionServiceImpl.java
@@ -68,7 +68,7 @@ public class QuestionServiceImpl implements QuestionService{
                 .id(email)
                 .email(email)
                 .build();
-        question.addCount();
+        question.increasedViews();
 
         questionRepository.save(question);
         questionEmailRepository.save(token);

--- a/src/main/java/com/danum/danum/service/board/village/VillageService.java
+++ b/src/main/java/com/danum/danum/service/board/village/VillageService.java
@@ -12,6 +12,6 @@ public interface VillageService {
 
     List<VillageViewDto> viewList();
 
-    VillageViewDto view(Long id);
+    VillageViewDto view(Long id, String email);
 
 }

--- a/src/main/java/com/danum/danum/service/board/village/VillageServiceImpl.java
+++ b/src/main/java/com/danum/danum/service/board/village/VillageServiceImpl.java
@@ -1,12 +1,16 @@
 package com.danum.danum.service.board.village;
 
+import com.danum.danum.domain.board.question.Question;
+import com.danum.danum.domain.board.question.QuestionEmailToken;
 import com.danum.danum.domain.board.village.Village;
+import com.danum.danum.domain.board.village.VillageEmailToken;
 import com.danum.danum.domain.board.village.VillageMapper;
 import com.danum.danum.domain.board.village.VillageNewDto;
 import com.danum.danum.domain.board.village.VillageViewDto;
 import com.danum.danum.exception.custom.BoardException;
 import com.danum.danum.exception.ErrorCode;
 import com.danum.danum.exception.custom.MemberException;
+import com.danum.danum.repository.VillageEmailRepository;
 import com.danum.danum.repository.VillageRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,6 +26,8 @@ public class VillageServiceImpl implements VillageService{
     private final VillageRepository villageRepository;
 
     private final VillageMapper villageMapper;
+
+    private final VillageEmailRepository villageEmailRepository;
 
     @Override
     @Transactional
@@ -48,10 +54,26 @@ public class VillageServiceImpl implements VillageService{
 
     @Override
     @Transactional
-    public VillageViewDto view(Long id) {
+    public VillageViewDto view(Long id, String email) {
         Village village = villageRepository.findById(id)
                 .orElseThrow(() -> new BoardException(ErrorCode.BOARD_NOT_FOUND_EXCEPTION));
+        viewCheck(village, email);
+
         return new VillageViewDto().toEntity(village);
+    }
+
+    private void viewCheck(Village village, String email) {
+        if (villageEmailRepository.existsById(email)) {
+            return;
+        }
+        VillageEmailToken token = VillageEmailToken.builder()
+                .id(email)
+                .email(email)
+                .build();
+        village.increasedViews();
+
+        villageRepository.save(village);
+        villageEmailRepository.save(token);
     }
 
 }

--- a/src/main/java/com/danum/danum/service/board/village/VillageServiceImpl.java
+++ b/src/main/java/com/danum/danum/service/board/village/VillageServiceImpl.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -63,11 +64,13 @@ public class VillageServiceImpl implements VillageService{
     }
 
     private void viewCheck(Village village, String email) {
-        if (villageEmailRepository.existsById(email)) {
+        Optional<VillageEmailToken> optionalVillageEmailToken = villageEmailRepository.findById(village.getId());
+        if (optionalVillageEmailToken.isPresent() && optionalVillageEmailToken.get().getEmail().equals(email)) {
             return;
         }
+
         VillageEmailToken token = VillageEmailToken.builder()
-                .id(email)
+                .id(village.getId())
                 .email(email)
                 .build();
         village.increasedViews();


### PR DESCRIPTION
## 수정 사항
> 기존에 클라이언트에게 로그인한 사용자 이메일을 가져오는 방식에서
> 로그인한 토큰에서 이메일을 꺼내오도록 수정

## 추가 사항
> 마을 게시판에 조회수 기능을 추가하였습니다.

## 변동 사항
> 클라이언트에게 데이터를 보낼 때 조회수를 안보내는 문제가 발생해 보내도록 수정

> redis에 key를 게시물에 id로 변경하여 문제가 발생하지 않도록 수정 비교할 때 해당 게시물 id에 조회할려는 email이 있는 지 비교한 후 없으면 조회수 증가
 