### PR TITLE
refactor: JwtUtil, AuthController logic

### DIFF
--- a/src/main/java/com/danum/danum/controller/jwt/AuthController.java
+++ b/src/main/java/com/danum/danum/controller/jwt/AuthController.java
@@ -1,0 +1,35 @@
+package com.danum.danum.controller.jwt;
+
+import com.danum.danum.exception.ErrorCode;
+import com.danum.danum.util.jwt.JwtUtil;
+import com.danum.danum.exception.custom.CustomJwtException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final JwtUtil jwtUtil;
+
+    @PostMapping("/refresh")
+    public ResponseEntity<String> refreshToken(@RequestHeader("Authorization") String refreshToken) {
+        if (refreshToken == null || !refreshToken.startsWith("Bearer ")) {
+            throw new CustomJwtException(ErrorCode.TOKEN_SIGNATURE_EXCEPTION);
+        }
+
+        String token = refreshToken.substring(7);
+        String newAccessToken = jwtUtil.reissueAccessToken(token);
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.TEXT_PLAIN)
+                .body(newAccessToken);
+    }
+}

--- a/src/main/java/com/danum/danum/util/jwt/JwtUtil.java
+++ b/src/main/java/com/danum/danum/util/jwt/JwtUtil.java
@@ -120,4 +120,13 @@ public class JwtUtil {
         return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
 
+    public String reissueAccessToken(String refreshToken) {
+
+        Authentication authentication = getAuthentication(refreshToken);
+
+        Date now = new Date();
+        Date accessTokenExpired = new Date(now.getTime() + accessTokenExpiredTime);
+
+        return getNewToken(accessTokenExpired, authentication);
+    }
 }


### PR DESCRIPTION
JwtUtil - getNewToken메소드 가져다쓰는 reissueAccessToken메소드 구현
AuthController - 리프레시토큰 이용해서 액세스토큰 재발급 기능