### PR TITLE
feat: 1:1 채팅 로직 및 직렬화 로직

### DIFF
--- a/src/main/java/com/danum/danum/config/RedisConfig.java
+++ b/src/main/java/com/danum/danum/config/RedisConfig.java
@@ -23,8 +23,8 @@ public class RedisConfig {
     @Value("${spring.redis.port}")
     private int redisPort;
 
-//    @Value("${spring.redis.password}")
-//    private String redisPassword;
+    @Value("${spring.redis.password}")
+    private String redisPassword;
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {

--- a/src/main/java/com/danum/danum/config/RedisConfig.java
+++ b/src/main/java/com/danum/danum/config/RedisConfig.java
@@ -23,8 +23,8 @@ public class RedisConfig {
     @Value("${spring.redis.port}")
     private int redisPort;
 
-    @Value("${spring.redis.password}")
-    private String redisPassword;
+//    @Value("${spring.redis.password}")
+//    private String redisPassword;
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
@@ -32,7 +32,7 @@ public class RedisConfig {
         RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
         config.setHostName(redisHost);
         config.setPort(redisPort);
-        config.setPassword(redisPassword);
+//        config.setPassword(redisPassword);
         return new LettuceConnectionFactory(config);
     }
 
@@ -62,8 +62,6 @@ public class RedisConfig {
         return new ChannelTopic("chatroom");
     }
 
-
-    // 레디스 탬플릿 설정
     @Bean
     public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
         // RedisTemplate 객체를 생성하고 연결 팩토리를 설정
@@ -74,4 +72,6 @@ public class RedisConfig {
         redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
         return redisTemplate;
     }
+
+    // 레디스 탬플릿 설정
 }

--- a/src/main/java/com/danum/danum/controller/admin/AdminController.java
+++ b/src/main/java/com/danum/danum/controller/admin/AdminController.java
@@ -4,6 +4,8 @@ import com.danum.danum.domain.board.question.Question;
 import com.danum.danum.domain.board.question.QuestionViewDto;
 import com.danum.danum.domain.board.village.Village;
 import com.danum.danum.domain.board.village.VillageViewDto;
+import com.danum.danum.domain.comment.question.QuestionComment;
+import com.danum.danum.domain.comment.village.VillageComment;
 import com.danum.danum.domain.member.Member;
 import com.danum.danum.service.admin.AdminService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -99,16 +101,21 @@ public class AdminController {
         return ResponseEntity.ok().build();
     }
 
-    // 댓글 삭제 (질문 또는 마을 게시글)
-    @DeleteMapping("/{type}/comments/{id}")
-    public ResponseEntity<Void> deleteComment(@PathVariable("type") String type, @PathVariable("id") Long id) {
-        if ("questions".equals(type)) {
-            adminService.deleteQuestionComment(id);
-        } else if ("villages".equals(type)) {
-            adminService.deleteVillageComment(id);
-        } else {
-            return ResponseEntity.badRequest().build();
-        }
+    // 질문 댓글 삭제
+    @DeleteMapping("/questions/{questionId}/comments/{commentId}")
+    public ResponseEntity<Void> deleteQuestionComment(
+            @PathVariable("questionId") Long questionId,
+            @PathVariable("commentId") Long commentId) {
+        adminService.deleteQuestionComment(questionId, commentId);
+        return ResponseEntity.ok().build();
+    }
+
+    // 마을 게시글 댓글 삭제
+    @DeleteMapping("/villages/{villageId}/comments/{commentId}")
+    public ResponseEntity<Void> deleteVillageComment(
+            @PathVariable("villageId") Long villageId,
+            @PathVariable("commentId") Long commentId) {
+        adminService.deleteVillageComment(villageId, commentId);
         return ResponseEntity.ok().build();
     }
 
@@ -121,6 +128,20 @@ public class AdminController {
     @GetMapping("/village/{id}")
     public ResponseEntity<VillageViewDto> getVillageById(@PathVariable("id") Long id){
         return ResponseEntity.ok(adminService.getVillageView(id));
+    }
+
+    //질문게시글안에 있는 댓글 삭제
+    @GetMapping("/questions/{questionId}/comments")
+    public ResponseEntity<List<QuestionComment>> getQuestionComments(@PathVariable Long questionId) {
+        List<QuestionComment> comments = adminService.getQuestionComments(questionId);
+        return ResponseEntity.ok(comments);
+    }
+
+    //마을게시글안에 있는 댓글 삭제
+    @GetMapping("/villages/{villageId}/comments")
+    public ResponseEntity<List<VillageComment>> getVillageComments(@PathVariable Long villageId) {
+        List<VillageComment> comments = adminService.getVillageComments(villageId);
+        return ResponseEntity.ok(comments);
     }
 
 }

--- a/src/main/java/com/danum/danum/controller/chat/ChatController.java
+++ b/src/main/java/com/danum/danum/controller/chat/ChatController.java
@@ -1,6 +1,7 @@
 package com.danum.danum.controller.chat;
 
 import com.danum.danum.domain.chat.ChatMessage;
+import com.danum.danum.domain.chat.ChatRoom;
 import com.danum.danum.repository.ChatRoomRepository;
 import com.danum.danum.service.chat.ChatService;
 import com.danum.danum.service.chat.RedisPublisher;
@@ -12,11 +13,10 @@ import org.springframework.stereotype.Controller;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
-@RestController
+@Controller
 public class ChatController {
 
     @Autowired
@@ -33,22 +33,27 @@ public class ChatController {
 
     @MessageMapping("/chat/message")
     public void message(@Payload ChatMessage message) {
+        ChatRoom chatRoom = chatRoomRepository.findRoomById(message.getRoomId());
+
+        if (chatRoom == null) {
+            return; // 채팅방이 존재하지 않으면 메시지 처리하지 않음
+        }
+
+        if (chatRoom.isOneToOne() && !chatRoom.isValidOneToOneParticipant(message.getSender())) {
+            return; // 1:1 채팅방에 유효한 참여자가 아니면 메시지 처리하지 않음
+        }
+
         if (ChatMessage.MessageType.ENTER.equals(message.getType())) {
             chatRoomRepository.enterChatRoom(message.getRoomId());
             message.setMessage(message.getSender() + "님이 입장하셨습니다.");
 
             // 채팅방에 입장할 때 기존 메시지들을 WebSocket으로 전송
-            List<Object> previousMessages = chatRoomRepository.getMessages(message.getRoomId());
+            List<ChatMessage> previousMessages = chatRoomRepository.getMessages(message.getRoomId());
             for (Object prevMsg : previousMessages) {
                 if (prevMsg instanceof ChatMessage) {
                     messagingTemplate.convertAndSend("/sub/chat/room/" + message.getRoomId(), prevMsg);
                 }
             }
-        }
-
-        // 새 메시지 저장 및 발행
-        if (ChatMessage.MessageType.TALK.equals(message.getType())) {
-            chatRoomRepository.saveChatMessage(message);
         }
 
         // Websocket에 발행된 메시지를 Redis로 발행한다(publish)

--- a/src/main/java/com/danum/danum/domain/chat/ChatMessage.java
+++ b/src/main/java/com/danum/danum/domain/chat/ChatMessage.java
@@ -1,5 +1,9 @@
 package com.danum.danum.domain.chat;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -16,5 +20,7 @@ public class ChatMessage {
     private String roomId; // 방번호
     private String sender; // 메시지 보낸사람
     private String message; // 메시지
-    private LocalDateTime timestamp; // 메시지 전송 시간
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    private LocalDateTime timestamp;
 }

--- a/src/main/java/com/danum/danum/domain/chat/ChatRoom.java
+++ b/src/main/java/com/danum/danum/domain/chat/ChatRoom.java
@@ -38,4 +38,13 @@ public class ChatRoom implements Serializable {
         chatRoom.participants = new HashSet<>(Set.of(user1, user2));
         return chatRoom;
     }
+
+    // 사용자 검증
+    public boolean isParticipant(String userId) {
+        return participants.contains(userId);
+    }
+    // 사용자가 2명 이상일시 검증
+    public boolean isValidOneToOneParticipant(String userId) {
+        return isOneToOne && participants.size() == 2 && isParticipant(userId);
+    }
 }

--- a/src/main/java/com/danum/danum/repository/comment/QuestionCommentRepository.java
+++ b/src/main/java/com/danum/danum/repository/comment/QuestionCommentRepository.java
@@ -1,5 +1,6 @@
 package com.danum.danum.repository.comment;
 
+import com.danum.danum.domain.board.question.Question;
 import com.danum.danum.domain.comment.question.QuestionComment;
 import com.danum.danum.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,4 +15,5 @@ public interface QuestionCommentRepository extends JpaRepository<QuestionComment
 
     List<QuestionComment> findAllByMember(Member member);
 
+    List<QuestionComment> findAllByQuestion(Question question);
 }

--- a/src/main/java/com/danum/danum/repository/comment/VillageCommentRepository.java
+++ b/src/main/java/com/danum/danum/repository/comment/VillageCommentRepository.java
@@ -1,5 +1,8 @@
 package com.danum.danum.repository.comment;
 
+import com.danum.danum.domain.board.question.Question;
+import com.danum.danum.domain.board.village.Village;
+import com.danum.danum.domain.comment.question.QuestionComment;
 import com.danum.danum.domain.comment.village.VillageComment;
 import com.danum.danum.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,5 +15,5 @@ public interface VillageCommentRepository extends JpaRepository<VillageComment, 
 
     List<VillageComment> findAllByVillageId(Long villageId);
     List<VillageComment> findAllByMember(Member member);
-
+    List<VillageComment> findAllByVillage(Village village);
 }

--- a/src/main/java/com/danum/danum/service/admin/AdminService.java
+++ b/src/main/java/com/danum/danum/service/admin/AdminService.java
@@ -4,6 +4,8 @@ import com.danum.danum.domain.board.question.Question;
 import com.danum.danum.domain.board.question.QuestionViewDto;
 import com.danum.danum.domain.board.village.Village;
 import com.danum.danum.domain.board.village.VillageViewDto;
+import com.danum.danum.domain.comment.question.QuestionComment;
+import com.danum.danum.domain.comment.village.VillageComment;
 import com.danum.danum.domain.member.Member;
 
 import java.util.List;
@@ -23,8 +25,8 @@ public interface AdminService {
     void deleteVillage(Long id);
 
     // 댓글 관련 메서드
-    void deleteQuestionComment(Long commentId);
-    void deleteVillageComment(Long commentId);
+    void deleteQuestionComment(Long questionId, Long commentId);
+    void deleteVillageComment(Long villageId, Long commentId);
 
     // 회원 관련 메서드
     List<Member> getAllMembers();
@@ -37,4 +39,8 @@ public interface AdminService {
     List<QuestionViewDto> getMemberQuestions(String email);
     List<VillageViewDto> getMemberVillages(String email);
     Map<String, List<?>> getMemberComments(String email);
+
+    // 질문/마을 게시판에 작성된 글안에 있는 댓글 삭제
+    List<QuestionComment> getQuestionComments(Long questionId);
+    List<VillageComment> getVillageComments(Long villageId);
 }

--- a/src/main/java/com/danum/danum/service/admin/AdminServiceImpl.java
+++ b/src/main/java/com/danum/danum/service/admin/AdminServiceImpl.java
@@ -4,9 +4,12 @@ import com.danum.danum.domain.board.question.Question;
 import com.danum.danum.domain.board.question.QuestionViewDto;
 import com.danum.danum.domain.board.village.Village;
 import com.danum.danum.domain.board.village.VillageViewDto;
+import com.danum.danum.domain.comment.question.QuestionComment;
+import com.danum.danum.domain.comment.village.VillageComment;
 import com.danum.danum.domain.member.Member;
 import com.danum.danum.exception.ErrorCode;
 import com.danum.danum.exception.custom.BoardException;
+import com.danum.danum.exception.custom.CommentException;
 import com.danum.danum.exception.custom.MemberException;
 import com.danum.danum.repository.MemberRepository;
 import com.danum.danum.repository.board.QuestionRepository;
@@ -90,14 +93,33 @@ public class AdminServiceImpl implements AdminService {
     }
 
     @Override
-    public void deleteQuestionComment(Long commentId) {
-        questionCommentRepository.deleteById(commentId);
+    public void deleteQuestionComment(Long questionId, Long commentId) {
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new BoardException(ErrorCode.BOARD_NOT_FOUND_EXCEPTION));
+        QuestionComment comment = questionCommentRepository.findById(commentId)
+                .orElseThrow(() -> new CommentException(ErrorCode.COMMENT_NOT_FOUND_EXCEPTION));
+
+        if (!comment.getQuestion().getId().equals(questionId)) {
+            throw new CommentException(ErrorCode.COMMENT_NOT_FOUND_EXCEPTION);
+        }
+
+        questionCommentRepository.delete(comment);
     }
 
     @Override
-    public void deleteVillageComment(Long commentId) {
-        villageCommentRepository.deleteById(commentId);
+    public void deleteVillageComment(Long villageId, Long commentId) {
+        Village village = villageRepository.findById(villageId)
+                .orElseThrow(() -> new BoardException(ErrorCode.BOARD_NOT_FOUND_EXCEPTION));
+        VillageComment comment = villageCommentRepository.findById(commentId)
+                .orElseThrow(() -> new CommentException(ErrorCode.COMMENT_NOT_FOUND_EXCEPTION));
+
+        if (!comment.getVillage().getId().equals(villageId)) {
+            throw new CommentException(ErrorCode.COMMENT_NOT_FOUND_EXCEPTION);
+        }
+
+        villageCommentRepository.delete(comment);
     }
+
 
     @Override
     public List<Member> getAllMembers() {
@@ -151,4 +173,18 @@ public class AdminServiceImpl implements AdminService {
         comments.put("villageComments", villageCommentRepository.findAllByMember(member));
         return comments;
     }
+
+    @Override
+    public List<QuestionComment> getQuestionComments(Long questionId) {
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new BoardException(ErrorCode.BOARD_NOT_FOUND_EXCEPTION));
+        return questionCommentRepository.findAllByQuestion(question);
+    }
+    @Override
+    public List<VillageComment> getVillageComments(Long villageId) {
+        Village village = villageRepository.findById(villageId)
+                .orElseThrow(() -> new BoardException(ErrorCode.BOARD_NOT_FOUND_EXCEPTION));
+        return villageCommentRepository.findAllByVillage(village);
+    }
+
 }


### PR DESCRIPTION
그룹채팅방과 1:1채팅로직 분리 및 사용자 권한 검증 강화

Redis 저장소는 기본적으로 문자열 형태로 데이터 저장 -> 객체 그대로 저장하려고하면 Java 객체 직렬화 형식으로 저장되어,
데이터를 읽어올 때 데이터타입 불일치로 문제 발생으로 인해 역직렬화 로직 추가

