### PR TITLE
feat: URL upload api

### DIFF
--- a/src/main/java/com/danum/danum/controller/MemberController.java
+++ b/src/main/java/com/danum/danum/controller/MemberController.java
@@ -1,6 +1,5 @@
 package com.danum.danum.controller;
 
-
 import com.danum.danum.domain.member.DeleteDto;
 import com.danum.danum.domain.member.LoginDto;
 import com.danum.danum.domain.member.Member;
@@ -9,15 +8,14 @@ import com.danum.danum.domain.member.UpdateDto;
 import com.danum.danum.service.member.MemberService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 public class MemberController {
 
     private final MemberService memberService;
@@ -25,29 +23,31 @@ public class MemberController {
     @PostMapping("/member/join")
     public ResponseEntity<?> register(@RequestBody RegisterDto registerDto) {
         Member member = memberService.join(registerDto);
-
         return ResponseEntity.ok(member);
     }
 
     @PutMapping("/member/update")
     public ResponseEntity<?> update(@RequestBody UpdateDto updateDto){
         Member member = memberService.update(updateDto);
-
         return ResponseEntity.ok(member);
     }
 
     @PostMapping("/member/login")
     public ResponseEntity<?> login(@RequestBody LoginDto loginDto, HttpServletResponse response){
         String accessToken = memberService.login(loginDto, response);
-
         return ResponseEntity.ok(accessToken);
     }
 
     @DeleteMapping("/member/delete")
     public ResponseEntity<?> delete(@RequestBody DeleteDto deleteDto) {
         memberService.delete(deleteDto.getEmail());
-
         return ResponseEntity.ok("회원탈퇴에 성공하였습니다.");
     }
 
+    @GetMapping("/member/profile-image")
+    public ResponseEntity<String> getProfileImage(Authentication authentication) {
+        String email = authentication.getName();
+        String profileImageUri = memberService.getProfileImageUri(email);
+        return ResponseEntity.ok(profileImageUri);
+    }
 }

--- a/src/main/java/com/danum/danum/domain/board/question/Question.java
+++ b/src/main/java/com/danum/danum/domain/board/question/Question.java
@@ -39,7 +39,7 @@ public class Question {
     @OneToOne
     private OpenAiConversation conversation;
 
-    @Column(name = "question_title")
+    @Column(name = "question_title", columnDefinition = "TEXT")
     private String title;
 
     @Column(name = "question_content")

--- a/src/main/java/com/danum/danum/domain/board/village/Village.java
+++ b/src/main/java/com/danum/danum/domain/board/village/Village.java
@@ -34,7 +34,7 @@ public class Village {
     @JoinColumn(name = "member_email")
     private Member member;
 
-    @Column(name = "village_title")
+    @Column(name = "village_title", columnDefinition = "TEXT")
     private String title;
 
     @Column(name = "village_content")

--- a/src/main/java/com/danum/danum/domain/member/Member.java
+++ b/src/main/java/com/danum/danum/domain/member/Member.java
@@ -1,15 +1,6 @@
 package com.danum.danum.domain.member;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-import java.time.LocalDateTime;
-import java.util.Collection;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,6 +10,11 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Entity
 @NoArgsConstructor
@@ -46,7 +42,7 @@ public class Member {
     private int exp;
 
     @Column(name = "member_contribution")
-    private Integer contribution;  // int에서 Integer형으로 변경
+    private Integer contribution;
 
     @Enumerated(EnumType.STRING)
     @ColumnDefault("'USER'")
@@ -58,23 +54,31 @@ public class Member {
     private LocalDateTime joinDateTime;
 
     @Getter
-    @Column(name = "latitude") //사용자의 위도
+    @Column(name = "latitude")
     private Double latitude;
 
     @Getter
-    @Column(name ="longitude")// 사용자의 경도
+    @Column(name = "longitude")
     private Double longitude;
 
-    public void updateUserPassword(String password){
+    @Getter
+    @Column(name = "profile_image_uri")
+    private String profileImageUri;
+
+    public void updateUserPassword(String password) {
         this.password = password;
     }
 
-    public void updateUserPhone(String phone){
+    public void updateUserPhone(String phone) {
         this.phone = phone;
     }
 
-    public void updateUserName(String username){
+    public void updateUserName(String username) {
         this.name = username;
+    }
+
+    public void updateProfileImageUri(String profileImageUri) {
+        this.profileImageUri = profileImageUri;
     }
 
     public UserDetails mappingUserDetails() {
@@ -91,15 +95,15 @@ public class Member {
 
     public boolean isActive() {
         return contribution != null && contribution == 0;
-    }  //회원 기본 상태
+    }
 
     public void activate() {
         this.contribution = 0;
-    } // 회원 활동 중
+    }
 
     public void deactivate() {
         this.contribution = 1;
-    } // 회원 정지 중
+    }
 
     public void setContribution(Integer contribution) {
         this.contribution = contribution;

--- a/src/main/java/com/danum/danum/domain/member/MemberMapper.java
+++ b/src/main/java/com/danum/danum/domain/member/MemberMapper.java
@@ -17,6 +17,7 @@ public class MemberMapper {
                 .contribution(0)
                 .role(Role.USER)
                 .joinDateTime(LocalDateTime.now())
+                .profileImageUri(registerDto.getProfileImageUri())
                 .build();
 
     }

--- a/src/main/java/com/danum/danum/domain/member/RegisterDto.java
+++ b/src/main/java/com/danum/danum/domain/member/RegisterDto.java
@@ -21,6 +21,8 @@ public class RegisterDto {
 
     private Double longitude;
 
+    private String profileImageUri;
+
     public void settingPassword(String password){
         this.password = password;
     }

--- a/src/main/java/com/danum/danum/domain/member/UpdateDto.java
+++ b/src/main/java/com/danum/danum/domain/member/UpdateDto.java
@@ -15,4 +15,6 @@ public class UpdateDto {
 
     private String name;
 
+    private String profileImageUri;
+
 }

--- a/src/main/java/com/danum/danum/exception/ErrorCode.java
+++ b/src/main/java/com/danum/danum/exception/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
     NICKNAME_EXCEPTION(HttpStatus.BAD_REQUEST, "M004", "이미 사용중인 닉네임입니다."),
     PASSWORD_NOT_MATCHED_EXCEPTION(HttpStatus.BAD_REQUEST, "M005", "패스워드가 틀렸습니다."),
     MEMBER_NOT_FOUND_EXCEPTION(HttpStatus.BAD_REQUEST, "M006", "존재하지 않는 회원 입니다."),
+    INVALID_PROFILE_IMAGE_EXCEPTION(HttpStatus.BAD_REQUEST, "I001", "올바르지 않은 프로필 이미지입니다."),
 
     BOARD_NOT_FOUND_EXCEPTION(HttpStatus.BAD_REQUEST, "B001", "존재하지 않는 게시판 입니다."),
 
@@ -30,6 +31,7 @@ public enum ErrorCode {
     MESSAGE_TYPE_NOT_SUPPORTED_EXCEPTION(HttpStatus.NOT_FOUND, "OA002", "지원되지 않는 메시지 타입입니다."),
     MULTIPLE_PROCESSING_MESSAGE_EXCEPTION(HttpStatus.BAD_REQUEST, "OA003", "진행중인 메시지가 하나보다 많습니다."),
     ALREADY_CLOSED_AI_CONVERSATION_EXCEPTION(HttpStatus.BAD_REQUEST, "OA004", "이미 닫힌 대화입니다.");
+
 
     private final HttpStatus status;
 

--- a/src/main/java/com/danum/danum/service/member/MemberService.java
+++ b/src/main/java/com/danum/danum/service/member/MemberService.java
@@ -6,6 +6,9 @@ import com.danum.danum.domain.member.RegisterDto;
 import com.danum.danum.domain.member.UpdateDto;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @Service
 public interface MemberService {
@@ -25,5 +28,7 @@ public interface MemberService {
     Member exp();
 
     Member contribution();
+
+    String getProfileImageUri(String email);
 
 }

--- a/src/main/java/com/danum/danum/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/danum/danum/service/member/MemberServiceImpl.java
@@ -30,11 +30,8 @@ public class MemberServiceImpl implements MemberService {
     private final static String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
 
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
-
     private final MemberRepository memberRepository;
-
     private final PasswordEncoder passwordEncoder;
-
     private final JwtUtil jwtUtil;
 
     @Override
@@ -93,6 +90,7 @@ public class MemberServiceImpl implements MemberService {
         String changePassword = updateDto.getPassword();
         String changePhone = updateDto.getPhone();
         String changeName = updateDto.getName();
+        String changeProfileImageUri = updateDto.getProfileImageUri();  // 추가
 
         if (StringUtils.hasText(changePassword)) {
             member.updateUserPassword(
@@ -103,6 +101,9 @@ public class MemberServiceImpl implements MemberService {
         }
         if (StringUtils.hasText(changeName)) {
             member.updateUserName(changeName);
+        }
+        if (StringUtils.hasText(changeProfileImageUri)) {  // 추가
+            member.updateProfileImageUri(changeProfileImageUri);
         }
 
         return memberRepository.save(member);
@@ -133,10 +134,10 @@ public class MemberServiceImpl implements MemberService {
         TokenDto accessToken = tokenBox.getAccessToken();
         TokenDto refreshToken = tokenBox.getRefreshToken();
 
-        Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken.getToken()); // 쿠키에 refresh 토큰 저장
-        cookie.setHttpOnly(true); // Javascript 접근 방지
-        cookie.setSecure(true); // HTTPS 전송만 허용
-        cookie.setPath("/"); // 쿠키 사용 경로 설정
+        Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken.getToken());
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
 
         response.addCookie(cookie);
 
@@ -177,4 +178,10 @@ public class MemberServiceImpl implements MemberService {
         return null;
     }
 
+    @Override
+    public String getProfileImageUri(String email) {
+        Member member = memberRepository.findById(email)
+                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND_EXCEPTION));
+        return member.getProfileImageUri();
+    }
 }


### PR DESCRIPTION
Member Entity - 사용자의 프로필 사진 URL 담을 필드 생성
MemberMapper - 받아온 사용자 프로필사진 URL을 Mapper에 등록

RegisterDto - 회원가입시 사용자 프로필 사진 URL을 담을 필드 생성
UpdateDto - 사용자가 프로필 사진을 변경을 할때 필요한 필드 생성

MemberController -  프론트 -> S3 이미지 URL 백엔드서버로 받는 api
MemberServiceImpl - 사용자 프로필사진 URL을 받는 getProfileImageUri 메소드 구현

ErrorCode - INVALID_PROFILE_IMAGE_EXCEPTION(HttpStatus.BAD_REQUEST, "I001", "올바르지 않은 프로필 이미지입니다.") 
                   커스텀 에러처리 생성

Question, Village - title필드가 varchar(255) 로 content 길이 부족으로 인해 TEXT로 변경
