### PR TITLE
QuestionComment 서비스 로직 개선

### DIFF
--- a/src/main/java/com/danum/danum/controller/comment/QuestionCommentController.java
+++ b/src/main/java/com/danum/danum/controller/comment/QuestionCommentController.java
@@ -59,13 +59,13 @@ public class QuestionCommentController {
         return authentication.getName();
     }
 
-    @PostMapping("/{questionId}/accept/{commentId}") // 이거 명세서 questionId 가 Id로 해야하나? 내일 고민하기 241003
+    @PostMapping("/{questionId}/accept/{commentId}")
     public ResponseEntity<?> acceptQuestionComment(@PathVariable Long questionId, @PathVariable Long commentId) {
         questionCommentService.acceptComment(questionId, commentId, getLoginUser());
         return ResponseEntity.ok("해당 답변을 채택하였습니다.");
     }
 
-    @PostMapping("/{questionId}/unaccept/{commentId}") // 이거 명세서 questionId 가 Id로 해야하나? 내일 고민하기 241003
+    @PostMapping("/{questionId}/unaccept/{commentId}")
     public ResponseEntity<?> unacceptQuestionComment(@PathVariable Long questionId, @PathVariable Long commentId) {
         questionCommentService.unacceptComment(questionId, commentId, getLoginUser());
         return ResponseEntity.ok("해당 답변 채택이 취소하였습니다.");

--- a/src/main/java/com/danum/danum/domain/comment/question/QuestionCommentViewDto.java
+++ b/src/main/java/com/danum/danum/domain/comment/question/QuestionCommentViewDto.java
@@ -23,7 +23,7 @@ public class QuestionCommentViewDto {
 
     private boolean isAccepted;
 
-    public QuestionCommentViewDto toEntity(QuestionComment questionComment) {
+    public static QuestionCommentViewDto toEntity(QuestionComment questionComment) {
         return QuestionCommentViewDto.builder()
                 .comment_id(questionComment.getId())
                 .email(questionComment.getMember().getEmail())

--- a/src/main/java/com/danum/danum/service/comment/QuestionCommentServiceImpl.java
+++ b/src/main/java/com/danum/danum/service/comment/QuestionCommentServiceImpl.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -33,98 +34,128 @@ public class QuestionCommentServiceImpl implements QuestionCommentService {
     @Override
     @Transactional
     public void create(QuestionCommentNewDto questionCommentNewDto) {
+        // 댓글 내용 유효성 검사
+        validateCommentContent(questionCommentNewDto.getContent());
+        // DTO를 엔티티로 변환하고 저장
         QuestionComment questionComment = questionCommentMapper.toEntity(questionCommentNewDto);
-
-        if (questionCommentNewDto.getContent().isEmpty()) {
-            throw new CommentException(ErrorCode.COMMENT_NOT_CONTENTS_EXCEPTION);
-        }
-
         questionCommentRepository.save(questionComment);
     }
 
     @Override
-    @Transactional
-    public List<QuestionCommentViewDto> viewList(Long id) {
-        List<QuestionComment> questionCommentList = questionCommentRepository.findAllByQuestionId(id);
-        List<QuestionCommentViewDto> commentViewList = new ArrayList<>();
-        for (QuestionComment questionComment : questionCommentList) {
-            commentViewList.add(new QuestionCommentViewDto().toEntity(questionComment));
-        }
-
-        return commentViewList;
+    @Transactional(readOnly = true)
+    public List<QuestionCommentViewDto> viewList(Long questionId) {
+        // 질문에 대한 모든 댓글을 조회하고 DTO로 변환
+        return questionCommentRepository.findAllByQuestionId(questionId).stream()
+                .map(this::convertToViewDto)
+                .collect(Collectors.toList());
     }
 
     @Override
     @Transactional
     public void update(QuestionCommentUpdateDto questionCommentUpdateDto, String loginUser) {
-        QuestionComment questionComment = questionCommentRepository.findById(questionCommentUpdateDto.getId())
-                .orElseThrow(() -> new CommentException(ErrorCode.COMMENT_NOT_FOUND_EXCEPTION));
-        userCheck(questionComment.getMember().getEmail(), loginUser);
+        // 댓글을 찾고 소유권 확인
+        QuestionComment questionComment = findCommentAndCheckOwnership(questionCommentUpdateDto.getId(), loginUser);
+        // 댓글 내용 업데이트
         questionComment.updateContent(questionCommentUpdateDto.getContent());
-
         questionCommentRepository.save(questionComment);
     }
 
     @Override
     @Transactional
     public void delete(Long id, String loginUser) {
-        QuestionComment questionComment = questionCommentRepository.findById(id)
-                        .orElseThrow(() -> new CommentException(ErrorCode.COMMENT_NOT_FOUND_EXCEPTION));
-        userCheck(questionComment.getMember().getEmail(), loginUser);
-
+        // 댓글을 찾고 소유권 확인
+        QuestionComment questionComment = findCommentAndCheckOwnership(id, loginUser);
+        // 댓글 삭제
         questionCommentRepository.delete(questionComment);
-    }
-
-    public void userCheck(String author, String loginUser) {
-        if (!author.equals(loginUser)) {
-            throw new CommentException(ErrorCode.COMMENT_NOT_AUTHOR_EXCEPTION);
-        }
     }
 
     @Override
     @Transactional
     public void acceptComment(Long questionId, Long commentId, String loginUser) {
-        Question question = questionRepository.findById(questionId)
-                .orElseThrow(() -> new CommentException(ErrorCode.QUESTION_NOT_FOUND_EXCEPTION));
-
-        if (!question.getMember().getEmail().equals(loginUser)) {
-            throw new CommentException(ErrorCode.NOT_QUESTION_AUTHOR_EXCEPTION);
-        }
-
-        QuestionComment comment = questionCommentRepository.findById(commentId)
-                .orElseThrow(() -> new CommentException(ErrorCode.COMMENT_NOT_FOUND_EXCEPTION));
-
+        // 질문을 찾고 소유권 확인
+        Question question = findQuestionAndCheckOwnership(questionId, loginUser);
         // 이미 채택된 댓글이 있는지 확인
-        if (questionCommentRepository.existsByQuestionAndIsAcceptedTrue(question)) {
-            throw new CommentException(ErrorCode.COMMENT_ALREADY_ACCEPTED_EXCEPTION);
-        }
-
-        comment.accept(); // 댓글을 채택 상태로 변경
-        questionCommentRepository.save(comment);
-
-        // 답변자의 경험치 증가
-        memberService.exp(comment.getMember().getEmail());
+        checkNoExistingAcceptedComment(question);
+        // 댓글 찾기
+        QuestionComment comment = findCommentById(commentId);
+        // 댓글 채택 및 작성자 보상
+        acceptCommentAndRewardAuthor(comment);
     }
 
     @Override
     @Transactional
     public void unacceptComment(Long questionId, Long commentId, String loginUser) {
+        // 질문을 찾고 소유권 확인
+        findQuestionAndCheckOwnership(questionId, loginUser);
+        // 댓글 찾기
+        QuestionComment comment = findCommentById(commentId);
+        // 댓글 채택 취소
+        unacceptComment(comment);
+    }
+
+    // 댓글 내용 유효성 검사
+    private void validateCommentContent(String content) {
+        if (content.isEmpty()) {
+            throw new CommentException(ErrorCode.COMMENT_NOT_CONTENTS_EXCEPTION);
+        }
+    }
+
+    // 댓글을 찾고 소유권 확인
+    private QuestionComment findCommentAndCheckOwnership(Long commentId, String loginUser) {
+        QuestionComment comment = findCommentById(commentId);
+        checkCommentOwnership(comment, loginUser);
+        return comment;
+    }
+
+    // 댓글 ID로 댓글 찾기
+    private QuestionComment findCommentById(Long commentId) {
+        return questionCommentRepository.findById(commentId)
+                .orElseThrow(() -> new CommentException(ErrorCode.COMMENT_NOT_FOUND_EXCEPTION));
+    }
+
+    // 댓글 소유권 확인
+    private void checkCommentOwnership(QuestionComment comment, String loginUser) {
+        if (!comment.getMember().getEmail().equals(loginUser)) {
+            throw new CommentException(ErrorCode.COMMENT_NOT_AUTHOR_EXCEPTION);
+        }
+    }
+
+    // 질문을 찾고 소유권 확인
+    private Question findQuestionAndCheckOwnership(Long questionId, String loginUser) {
         Question question = questionRepository.findById(questionId)
                 .orElseThrow(() -> new CommentException(ErrorCode.QUESTION_NOT_FOUND_EXCEPTION));
-
         if (!question.getMember().getEmail().equals(loginUser)) {
             throw new CommentException(ErrorCode.NOT_QUESTION_AUTHOR_EXCEPTION);
         }
+        return question;
+    }
 
-        QuestionComment comment = questionCommentRepository.findById(commentId)
-                .orElseThrow(() -> new CommentException(ErrorCode.COMMENT_NOT_FOUND_EXCEPTION));
+    // 이미 채택된 댓글이 있는지 확인
+    private void checkNoExistingAcceptedComment(Question question) {
+        if (questionCommentRepository.existsByQuestionAndIsAcceptedTrue(question)) {
+            throw new CommentException(ErrorCode.COMMENT_ALREADY_ACCEPTED_EXCEPTION);
+        }
+    }
 
+    // 댓글 채택 및 작성자 보상
+    private void acceptCommentAndRewardAuthor(QuestionComment comment) {
+        comment.accept();
+        questionCommentRepository.save(comment);
+        memberService.exp(comment.getMember().getEmail());
+    }
+
+    // 댓글 채택 취소
+    private void unacceptComment(QuestionComment comment) {
         if (!comment.isAccepted()) {
             throw new CommentException(ErrorCode.COMMENT_NOT_ACCEPTED_EXCEPTION);
         }
-
         comment.unaccept();
         questionCommentRepository.save(comment);
+    }
+
+    // QuestionComment 엔티티를 QuestionCommentViewDto로 변환
+    private QuestionCommentViewDto convertToViewDto(QuestionComment questionComment) {
+        return new QuestionCommentViewDto().toEntity(questionComment);
     }
 
 }


### PR DESCRIPTION
메소드 분리로써 단일 책임 원칙을 더 준수하며 전반적인 효율성 개선

QuestionCommentServiceImpl의 코드 구조 및 가독성 향상
QuestionCommentMapper 사용 최적화
이해를 돕기 위한 한국어 주석 추가
예외 처리 개선
관심사를 더 작고 집중된 메소드로 분리
수정된 메소드:

create(): QuestionCommentMapper를 사용하여 엔티티 변환
viewList(): 효율적인 리스트 처리를 위한 스트림 API 구현
update(): 댓글 소유권 확인 개선
delete(): 댓글 검색 및 소유권 확인 강화
acceptComment(): 질문 찾기, 소유권 확인, 댓글 채택 로직 분리
unacceptComment(): 댓글 채택 취소 로직 개선
새로운 헬퍼 메소드:

validateCommentContent(): 댓글 내용 유효성 검사
findCommentAndCheckOwnership(): 댓글 찾기 및 소유권 확인
findCommentById(): ID로 댓글 검색
checkCommentOwnership(): 댓글 소유권 확인
findQuestionAndCheckOwnership(): 질문 찾기 및 소유권 확인
checkNoExistingAcceptedComment(): 기존 채택된 댓글 확인
acceptCommentAndRewardAuthor(): 댓글 채택 및 작성자 보상
unacceptComment(): 댓글 채택 취소
QuestionCommentViewDto: static으로 선언
convertToViewDto(): QuestionCommentViewDto 메서드의 파라미터로 QuestionComment 엔티티를 받도록 변경
