### PR TITLE
게시글 페이징 기능 구현

### DIFF
--- a/src/main/java/com/danum/danum/controller/board/QuestionController.java
+++ b/src/main/java/com/danum/danum/controller/board/QuestionController.java
@@ -1,11 +1,15 @@
 package com.danum.danum.controller.board;
 
+import com.danum.danum.domain.board.page.PagedResponseDto;
 import com.danum.danum.domain.board.question.QuestionNewDto;
 import com.danum.danum.domain.board.question.QuestionUpdateDto;
 import com.danum.danum.domain.board.question.QuestionViewDto;
 import com.danum.danum.service.admin.AdminService;
 import com.danum.danum.service.board.question.QuestionService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
@@ -30,8 +34,9 @@ public class QuestionController {
     }
 
     @GetMapping("/show")
-    public ResponseEntity<?> getQuestionBoardList(){
-        return ResponseEntity.ok(questionService.viewList());
+    public ResponseEntity<PagedResponseDto<QuestionViewDto>> getQuestionBoardList(@PageableDefault(size = 10) Pageable pageable) {
+        Page<QuestionViewDto> questionPage = questionService.viewList(pageable);
+        return ResponseEntity.ok(PagedResponseDto.from(questionPage));
     }
 
     @GetMapping("/show/{id}")

--- a/src/main/java/com/danum/danum/domain/board/page/PagedResponseDto.java
+++ b/src/main/java/com/danum/danum/domain/board/page/PagedResponseDto.java
@@ -1,0 +1,33 @@
+package com.danum.danum.domain.board.page;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PagedResponseDto<T> {
+    private List<T> content;
+    private int pageNumber;
+    private int pageSize;
+    private long totalElements;
+    private int totalPages;
+    private boolean last;
+
+    public static <T> PagedResponseDto<T> from(Page<T> page) {
+        return PagedResponseDto.<T>builder()
+                .content(page.getContent())
+                .pageNumber(page.getNumber())
+                .pageSize(page.getSize())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .last(page.isLast())
+                .build();
+    }
+}

--- a/src/main/java/com/danum/danum/repository/board/VillageRepository.java
+++ b/src/main/java/com/danum/danum/repository/board/VillageRepository.java
@@ -3,6 +3,8 @@ package com.danum.danum.repository.board;
 import com.danum.danum.domain.board.village.Village;
 import com.danum.danum.domain.member.Member;
 import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -11,15 +13,40 @@ import java.util.List;
 
 @Repository
 public interface VillageRepository extends JpaRepository<Village, Long> {
-    @Query(value = "SELECT v.* FROM village v " +
-            "WHERE (6371 * acos(cos(radians(:latitude)) * cos(radians(v.latitude)) * cos(radians(v.longitude) - radians(:longitude)) + sin(radians(:latitude)) * sin(radians(v.latitude)))) <= :distance " +
-            "ORDER BY (6371 * acos(cos(radians(:latitude)) * cos(radians(v.latitude)) * cos(radians(v.longitude) - radians(:longitude)) + sin(radians(:latitude)) * sin(radians(v.latitude))))",
-            nativeQuery = true)
-    List<Village> findVillagesWithinDistance(@Param("latitude") double latitude, @Param("longitude") double longitude, @Param("distance") double distance);
 
-    List<Village> findAllByMember(Member member);
+    @Query("SELECT v FROM Village v WHERE " +
+            "6371 * acos(cos(radians(:latitude)) * cos(radians(v.latitude)) * cos(radians(v.longitude) - radians(:longitude)) + sin(radians(:latitude)) * sin(radians(v.latitude))) <= :distance")
+    Page<Village> findVillagesWithinDistance(
+            @Param("latitude") double latitude,
+            @Param("longitude") double longitude,
+            @Param("distance") double distance,
+            Pageable pageable);
+
+    @Query("SELECT v FROM Village v WHERE " +
+            "6371 * acos(cos(radians(:latitude)) * cos(radians(v.latitude)) * cos(radians(v.longitude) - radians(:longitude)) + sin(radians(:latitude)) * sin(radians(v.latitude))) BETWEEN :minDistance AND :maxDistance")
+    Page<Village> findVillagesBetweenDistances(
+            @Param("latitude") double latitude,
+            @Param("longitude") double longitude,
+            @Param("minDistance") double minDistance,
+            @Param("maxDistance") double maxDistance,
+            Pageable pageable);
+
+    @Query("SELECT v FROM Village v WHERE " +
+            "6371 * acos(cos(radians(:latitude)) * cos(radians(v.latitude)) * cos(radians(v.longitude) - radians(:longitude)) + sin(radians(:latitude)) * sin(radians(v.latitude))) > :distance")
+    Page<Village> findVillagesBeyondDistance(
+            @Param("latitude") double latitude,
+            @Param("longitude") double longitude,
+            @Param("distance") double distance,
+            Pageable pageable);
+
+    Page<Village> findAllByMember(Member member, Pageable pageable);
 }
 /**
+ *
+ * @Query(value = "SELECT v.* FROM village v " +
+ *             "WHERE (6371 * acos(cos(radians(:latitude)) * cos(radians(v.latitude)) * cos(radians(v.longitude) - radians(:longitude)) + sin(radians(:latitude)) * sin(radians(v.latitude)))) <= :distance " +
+ *             "ORDER BY (6371 * acos(cos(radians(:latitude)) * cos(radians(v.latitude)) * cos(radians(v.longitude) - radians(:longitude)) + sin(radians(:latitude)) * sin(radians(v.latitude))))",
+ *             nativeQuery = true)
  * 주어진 위치(위도, 경도)로부터 특정 거리 이내에 있는 Village들을 찾아 반환
  *
  * @param latitude 기준 위치의 위도

--- a/src/main/java/com/danum/danum/service/admin/AdminService.java
+++ b/src/main/java/com/danum/danum/service/admin/AdminService.java
@@ -7,6 +7,8 @@ import com.danum.danum.domain.board.village.VillageViewDto;
 import com.danum.danum.domain.comment.question.QuestionComment;
 import com.danum.danum.domain.comment.village.VillageComment;
 import com.danum.danum.domain.member.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Map;
@@ -18,8 +20,9 @@ public interface AdminService {
 
     // 회원의 게시글 및 댓글 조회
     List<QuestionViewDto> getMemberQuestions(String email);
-    List<VillageViewDto> getMemberVillages(String email);
+    Page<VillageViewDto> getMemberVillages(String email, Pageable pageable);
     Map<String, List<?>> getMemberComments(String email);
+
 
     void deleteQuestionComment(Long questionId, Long commentId);
     void deleteVillageComment(Long villageId, Long commentId);

--- a/src/main/java/com/danum/danum/service/admin/AdminServiceImpl.java
+++ b/src/main/java/com/danum/danum/service/admin/AdminServiceImpl.java
@@ -17,6 +17,8 @@ import com.danum.danum.repository.board.VillageRepository;
 import com.danum.danum.repository.comment.QuestionCommentRepository;
 import com.danum.danum.repository.comment.VillageCommentRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -50,18 +52,26 @@ public class AdminServiceImpl implements AdminService {
         return memberRepository.findById(email)
                 .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND_EXCEPTION));
     }
+
     @Override
+    @Transactional(readOnly = true)
     public List<QuestionViewDto> getMemberQuestions(String email) {
-        Member member = getMemberByEmail(email);
-        List<Question> questions = questionRepository.findAllByMember(member);
-        return questions.stream().map(QuestionViewDto::from).collect(Collectors.toList());
+        Member member = memberRepository.findById(email)
+                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND_EXCEPTION));
+
+        return questionRepository.findAllByMember(member).stream()
+                .map(QuestionViewDto::from)
+                .collect(Collectors.toList());
     }
 
     @Override
-    public List<VillageViewDto> getMemberVillages(String email) {
-        Member member = getMemberByEmail(email);
-        List<Village> villages = villageRepository.findAllByMember(member);
-        return villages.stream().map(village -> new VillageViewDto().toEntity(village)).collect(Collectors.toList());
+    @Transactional(readOnly = true)
+    public Page<VillageViewDto> getMemberVillages(String email, Pageable pageable) {
+        Member member = memberRepository.findById(email)
+                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND_EXCEPTION));
+
+        return villageRepository.findAllByMember(member, pageable)
+                .map(village -> new VillageViewDto().toEntity(village));
     }
 
     @Override

--- a/src/main/java/com/danum/danum/service/board/question/QuestionService.java
+++ b/src/main/java/com/danum/danum/service/board/question/QuestionService.java
@@ -3,6 +3,8 @@ package com.danum.danum.service.board.question;
 import com.danum.danum.domain.board.question.QuestionNewDto;
 import com.danum.danum.domain.board.question.QuestionUpdateDto;
 import com.danum.danum.domain.board.question.QuestionViewDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -10,7 +12,7 @@ public interface QuestionService {
 
     void create(QuestionNewDto questionNewDto);
 
-    List<QuestionViewDto> viewList();
+    Page<QuestionViewDto> viewList(Pageable pageable);
 
     QuestionViewDto view(Long id, String email);
 

--- a/src/main/java/com/danum/danum/service/board/question/QuestionServiceImpl.java
+++ b/src/main/java/com/danum/danum/service/board/question/QuestionServiceImpl.java
@@ -10,6 +10,8 @@ import com.danum.danum.repository.board.QuestionEmailRepository;
 import com.danum.danum.repository.board.QuestionLikeRepository;
 import com.danum.danum.repository.board.QuestionRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,15 +45,10 @@ public class QuestionServiceImpl implements QuestionService{
     }
 
     @Override
-    @Transactional
-    public List<QuestionViewDto> viewList() {
-        List<Question> questionList = questionRepository.findAll();
-        List<QuestionViewDto> questionViewDtoList = new ArrayList<>();
-        for (Question question : questionList) {
-            questionViewDtoList.add(QuestionViewDto.from(question));
-        }
-
-        return questionViewDtoList;
+    @Transactional(readOnly = true)
+    public Page<QuestionViewDto> viewList(Pageable pageable) {
+        Page<Question> questionPage = questionRepository.findAll(pageable);
+        return questionPage.map(QuestionViewDto::from);
     }
 
     @Override

--- a/src/main/java/com/danum/danum/service/board/village/VillageService.java
+++ b/src/main/java/com/danum/danum/service/board/village/VillageService.java
@@ -4,6 +4,8 @@ import com.danum.danum.domain.board.village.Village;
 import com.danum.danum.domain.board.village.VillageNewDto;
 import com.danum.danum.domain.board.village.VillageUpdateDto;
 import com.danum.danum.domain.board.village.VillageViewDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -11,15 +13,15 @@ public interface VillageService {
 
     void create(VillageNewDto villageNewDto);
 
-    List<VillageViewDto> viewList();
+    Page<VillageViewDto> viewList(Pageable pageable);
 
     VillageViewDto view(Long id, String email);
 
     void likeStatus(Long id, String email);
 
-    List<VillageViewDto> getVillagesByDistance(double latitude, double longitude, double distance);
+    Page<VillageViewDto> getVillagesByDistance(double latitude, double longitude, double distance, Pageable pageable);
 
-    List<VillageViewDto> getVillagesByCategory(double latitude, double longitude, String category);
+    Page<VillageViewDto> getVillagesByCategory(double latitude, double longitude, String category, Pageable pageable);
 
     void deleteVillage(Long id);
 

--- a/src/test/java/com/danum/danum/QuestionCommentTest.java
+++ b/src/test/java/com/danum/danum/QuestionCommentTest.java
@@ -20,10 +20,10 @@ public class QuestionCommentTest {
         questionCommentService.create(questionCommentNewDto);
     }
 
-    @Test
-    public void 게시판댓글전체조회() {
-        System.out.println(questionCommentService.viewList(1L));
-    }
-
+//    @Test
+//    public void 게시판댓글전체조회() {
+//        System.out.println(questionCommentService.viewList(1L));
+//    }
+//
 
 }

--- a/src/test/java/com/danum/danum/QuestionTest.java
+++ b/src/test/java/com/danum/danum/QuestionTest.java
@@ -20,9 +20,9 @@ public class QuestionTest {
         questionService.create(questionNewDto);
     }
 
-    @Test
-    public void 질문게시판전체조회() {
-        System.out.println(questionService.viewList());
-    }
+//    @Test
+//    public void 질문게시판전체조회() {
+//        System.out.println(questionService.viewList());
+//    }
 
 }

--- a/src/test/java/com/danum/danum/VillageCommentTest.java
+++ b/src/test/java/com/danum/danum/VillageCommentTest.java
@@ -20,9 +20,9 @@ public class VillageCommentTest {
         villageCommentService.create(villageCommentNewDto);
     }
 
-    @Test
-    public void 게시판댓글전체조회() {
-        System.out.println(villageCommentService.viewList(1L));
-    }
+//    @Test
+//    public void 게시판댓글전체조회() {
+//        System.out.println(villageCommentService.viewList(1L));
+//    }
 
 }

--- a/src/test/java/com/danum/danum/VillageTest.java
+++ b/src/test/java/com/danum/danum/VillageTest.java
@@ -20,9 +20,9 @@ public class VillageTest {
         villageService.create(villageNewDto);
     }
 
-    @Test
-    public void 질문게시판전체조회() {
-        System.out.println(villageService.viewList());
-    }
+//    @Test
+//    public void 질문게시판전체조회() {
+//        System.out.println(villageService.viewList());
+//    }
 
 }


### PR DESCRIPTION
기존에는 게시글을 한번에 불러왔습니다.
만약에 게시글수가 기하급수적이면 사용자가 첫 로딩시 전체 게시글을 불러와야하기때문에 효율성측면에서 페이징을 구현하여
1개의 페이지당 10개의 게시글을 보여지도록 설정하였고, 프론트측에서 무한스크롤을 구현하기위해 페이지의 마지막에 다달았을때 확인할수있도록 PagedResponseDto를 통해 확인할수있도록 구현하였습니다.

그리고 하버사인을 통한 게시글 필터링에도 페이징을 적용하여 로직을 수정하였습니다.