### PR TITLE
feat: 인기글 표시 및 동네/질문게시판 최신순으로 게시글 가져오는 기능

### DIFF
--- a/src/main/java/com/danum/danum/DanumApplication.java
+++ b/src/main/java/com/danum/danum/DanumApplication.java
@@ -2,8 +2,10 @@ package com.danum.danum;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class DanumApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/danum/danum/controller/board/MainPageController.java
+++ b/src/main/java/com/danum/danum/controller/board/MainPageController.java
@@ -1,0 +1,62 @@
+package com.danum.danum.controller;
+
+import com.danum.danum.domain.board.question.QuestionViewDto;
+import com.danum.danum.domain.board.village.VillageViewDto;
+import com.danum.danum.service.board.question.QuestionService;
+import com.danum.danum.service.board.village.VillageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/main")
+public class MainPageController {
+
+    private final QuestionService questionService;
+    private final VillageService villageService;
+
+    private Map<String, List<?>> cachedPopularPosts = new HashMap<>();
+
+    @GetMapping("/recent-posts")
+    public ResponseEntity<Map<String, List<?>>> getRecentPosts() {
+        PageRequest pageRequest = PageRequest.of(0, 5); // 첫 페이지, 5개 항목
+
+        List<QuestionViewDto> recentQuestions = questionService.viewList(pageRequest).getContent();
+        List<VillageViewDto> recentVillages = villageService.viewList(pageRequest).getContent();
+
+        Map<String, List<?>> response = new HashMap<>();
+        response.put("recentQuestions", recentQuestions);
+        response.put("recentVillages", recentVillages);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/popular-posts")
+    public ResponseEntity<Map<String, List<?>>> getPopularPosts() {
+        return ResponseEntity.ok(cachedPopularPosts);
+    }
+
+    @Scheduled(fixedRate = 300000) // 5분(300,000ms)마다 실행
+    @CacheEvict(value = "popularPosts", allEntries = true)
+    public void updatePopularPosts() {
+        int limit = 5;
+
+        List<QuestionViewDto> popularQuestions = questionService.getPopularQuestions(limit);
+        List<VillageViewDto> popularVillages = villageService.getPopularVillages(limit);
+
+        cachedPopularPosts = new HashMap<>();
+        cachedPopularPosts.put("popularQuestions", popularQuestions);
+        cachedPopularPosts.put("popularVillages", popularVillages);
+    }
+}

--- a/src/main/java/com/danum/danum/repository/board/QuestionRepository.java
+++ b/src/main/java/com/danum/danum/repository/board/QuestionRepository.java
@@ -2,12 +2,19 @@ package com.danum.danum.repository.board;
 
 import com.danum.danum.domain.board.question.Question;
 import com.danum.danum.domain.member.Member;
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
 public interface QuestionRepository extends JpaRepository<Question, Long> {
     List<Question> findAllByMember(Member member);
+
+    @Query("SELECT q FROM Question q ORDER BY q.view_count DESC")
+    List<Question> findPopularQuestions(Pageable pageable);
 }

--- a/src/main/java/com/danum/danum/repository/board/VillageRepository.java
+++ b/src/main/java/com/danum/danum/repository/board/VillageRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -40,22 +41,7 @@ public interface VillageRepository extends JpaRepository<Village, Long> {
             Pageable pageable);
 
     Page<Village> findAllByMember(Member member, Pageable pageable);
+
+    @Query("SELECT v FROM Village v ORDER BY v.view_count DESC")
+    List<Village> findPopularVillages(Pageable pageable);
 }
-/**
- *
- * @Query(value = "SELECT v.* FROM village v " +
- *             "WHERE (6371 * acos(cos(radians(:latitude)) * cos(radians(v.latitude)) * cos(radians(v.longitude) - radians(:longitude)) + sin(radians(:latitude)) * sin(radians(v.latitude)))) <= :distance " +
- *             "ORDER BY (6371 * acos(cos(radians(:latitude)) * cos(radians(v.latitude)) * cos(radians(v.longitude) - radians(:longitude)) + sin(radians(:latitude)) * sin(radians(v.latitude))))",
- *             nativeQuery = true)
- * 주어진 위치(위도, 경도)로부터 특정 거리 이내에 있는 Village들을 찾아 반환
- *
- * @param latitude 기준 위치의 위도
- * @param longitude 기준 위치의 경도
- * @param distance 검색할 최대 거리 (km)
- * @return 지정된 거리 이내에 있는 Village 목록
- *
- * 이 메서드는 다음과 같은 작업을 수행함
- * 1. 하버사인 공식을 사용하여 두 지점 사이의 거리를 계산
- * 2. 계산된 거리가 지정된 distance 이하인 Village들을 선택
- * 3. 결과를 거리에 따라 오름차순으로 정렬
- */

--- a/src/main/java/com/danum/danum/service/board/question/QuestionService.java
+++ b/src/main/java/com/danum/danum/service/board/question/QuestionService.java
@@ -6,6 +6,7 @@ import com.danum.danum.domain.board.question.QuestionViewDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface QuestionService {
@@ -22,6 +23,6 @@ public interface QuestionService {
 
     void update(QuestionUpdateDto questionUpdateDto, String loginUser);
 
-
+    List<QuestionViewDto> getPopularQuestions(int limit);
 
 }

--- a/src/main/java/com/danum/danum/service/board/question/QuestionServiceImpl.java
+++ b/src/main/java/com/danum/danum/service/board/question/QuestionServiceImpl.java
@@ -11,13 +11,16 @@ import com.danum.danum.repository.board.QuestionLikeRepository;
 import com.danum.danum.repository.board.QuestionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -125,5 +128,13 @@ public class QuestionServiceImpl implements QuestionService{
         if (!author.equals(loginUser)) {
             throw new BoardException(ErrorCode.BOARD_NOT_AUTHOR_EXCEPTION);
         }
+    }
+
+    @Override
+    public List<QuestionViewDto> getPopularQuestions(int limit) {
+        return questionRepository.findPopularQuestions(PageRequest.of(0, limit))
+                .stream()
+                .map(QuestionViewDto::from)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/danum/danum/service/board/village/VillageService.java
+++ b/src/main/java/com/danum/danum/service/board/village/VillageService.java
@@ -1,12 +1,12 @@
 package com.danum.danum.service.board.village;
 
-import com.danum.danum.domain.board.village.Village;
 import com.danum.danum.domain.board.village.VillageNewDto;
 import com.danum.danum.domain.board.village.VillageUpdateDto;
 import com.danum.danum.domain.board.village.VillageViewDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface VillageService {
@@ -26,4 +26,6 @@ public interface VillageService {
     void deleteVillage(Long id);
 
     void update(VillageUpdateDto villageUpdateDto, String loginUser);
+
+    List<VillageViewDto> getPopularVillages(int limit);
 }

--- a/src/main/java/com/danum/danum/service/board/village/VillageServiceImpl.java
+++ b/src/main/java/com/danum/danum/service/board/village/VillageServiceImpl.java
@@ -14,10 +14,12 @@ import com.danum.danum.repository.board.VillageLikeRepository;
 import com.danum.danum.repository.board.VillageRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -160,5 +162,13 @@ public class VillageServiceImpl implements VillageService{
         if (!author.equals(loginUser)) {
             throw new CommentException(ErrorCode.COMMENT_NOT_AUTHOR_EXCEPTION);
         }
+    }
+
+    @Override
+    public List<VillageViewDto> getPopularVillages(int limit) {
+        return villageRepository.findPopularVillages(PageRequest.of(0, limit))
+                .stream()
+                .map(village -> new VillageViewDto().toEntity(village))
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
-  마을/질문 게시판에 최신(시간) 순으로 게시글을 각각 5개씩 가져와 메인페이지 뿌려주는 기능 구현


-  인기글 표시하는 기능 ( 홈 화면 )
    - 인기글 산정 방식은 조회수로 정했고, 지정된 시간이 지나게되면 인기글 산정로직이 돌아가며 인기글이 산정됩니다
    - 해당 기능의 쿼리로 진행되기때문에 DanumApplication 파일에 @EnableScheduling 어노테이션을 사용하여 5분마다 실행되는 스케줄링 작업으로 구현하였습니다.