### PR TITLE
feat: 게시글에 댓글달린지 알수있는 알림기능

### DIFF
--- a/src/main/java/com/danum/danum/controller/board/MainPageController.java
+++ b/src/main/java/com/danum/danum/controller/board/MainPageController.java
@@ -2,16 +2,18 @@ package com.danum.danum.controller;
 
 import com.danum.danum.domain.board.question.QuestionViewDto;
 import com.danum.danum.domain.board.village.VillageViewDto;
+import com.danum.danum.domain.notification.Notification;
 import com.danum.danum.service.board.question.QuestionService;
 import com.danum.danum.service.board.village.VillageService;
+import com.danum.danum.service.notification.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
 import java.util.HashMap;
@@ -25,6 +27,7 @@ public class MainPageController {
 
     private final QuestionService questionService;
     private final VillageService villageService;
+    private final NotificationService notificationService;
 
     private Map<String, List<?>> cachedPopularPosts = new HashMap<>();
 
@@ -58,5 +61,25 @@ public class MainPageController {
         cachedPopularPosts = new HashMap<>();
         cachedPopularPosts.put("popularQuestions", popularQuestions);
         cachedPopularPosts.put("popularVillages", popularVillages);
+    }
+
+    @GetMapping("/notifications")
+    public ResponseEntity<List<Notification>> getNotifications(Authentication authentication) {
+        String userEmail = authentication.getName();
+        List<Notification> notifications = notificationService.getNotifications(userEmail);
+        return ResponseEntity.ok(notifications);
+    }
+
+    @GetMapping("/notifications/unread-count")
+    public ResponseEntity<Long> getUnreadNotificationCount(Authentication authentication) {
+        String userEmail = authentication.getName();
+        long unreadCount = notificationService.getUnreadCount(userEmail);
+        return ResponseEntity.ok(unreadCount);
+    }
+
+    @PostMapping("/notifications/{notificationId}/read")
+    public ResponseEntity<Void> markNotificationAsRead(@PathVariable Long notificationId) {
+        notificationService.markAsRead(notificationId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/danum/danum/domain/notification/Notification.java
+++ b/src/main/java/com/danum/danum/domain/notification/Notification.java
@@ -1,0 +1,52 @@
+package com.danum.danum.domain.notification;
+
+import com.danum.danum.domain.member.Member;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notifications")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_email")
+    private Member member;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private String link;
+
+    @Column(nullable = false)
+    private boolean isRead;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationType type;
+
+    public void markAsRead() {
+        this.isRead = true;
+    }
+
+    public enum NotificationType {
+        QUESTION_COMMENT,
+        VILLAGE_COMMENT
+    }
+}

--- a/src/main/java/com/danum/danum/repository/notification/NotificationRepository.java
+++ b/src/main/java/com/danum/danum/repository/notification/NotificationRepository.java
@@ -1,0 +1,14 @@
+package com.danum.danum.repository.notification;
+
+import com.danum.danum.domain.notification.Notification;
+import com.danum.danum.domain.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findByMemberOrderByCreatedAtDesc(Member member);
+    long countByMemberAndIsReadFalse(Member member);
+}

--- a/src/main/java/com/danum/danum/service/comment/QuestionCommentServiceImpl.java
+++ b/src/main/java/com/danum/danum/service/comment/QuestionCommentServiceImpl.java
@@ -6,11 +6,13 @@ import com.danum.danum.domain.comment.question.QuestionCommentMapper;
 import com.danum.danum.domain.comment.question.QuestionCommentNewDto;
 import com.danum.danum.domain.comment.question.QuestionCommentUpdateDto;
 import com.danum.danum.domain.comment.question.QuestionCommentViewDto;
+import com.danum.danum.domain.notification.Notification;
 import com.danum.danum.exception.ErrorCode;
 import com.danum.danum.exception.custom.CommentException;
 import com.danum.danum.repository.comment.QuestionCommentRepository;
 import com.danum.danum.repository.board.QuestionRepository;
 import com.danum.danum.service.member.MemberService;
+import com.danum.danum.service.notification.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,12 +33,19 @@ public class QuestionCommentServiceImpl implements QuestionCommentService {
 
     private final MemberService memberService;
 
+    private final NotificationService notificationService;
+
     @Override
     @Transactional
     public void create(QuestionCommentNewDto questionCommentNewDto) {
         validateCommentContent(questionCommentNewDto.getContent());
         QuestionComment questionComment = questionCommentMapper.toEntity(questionCommentNewDto);
         questionCommentRepository.save(questionComment);
+
+        Question question = questionComment.getQuestion();
+        String content = String.format("새로운 댓글: %s", questionComment.getContent());
+        String link = "/questions/" + question.getId();
+        notificationService.createNotification(question.getMember().getEmail(), content, link, Notification.NotificationType.QUESTION_COMMENT);
     }
 
     @Override

--- a/src/main/java/com/danum/danum/service/comment/VillageCommentServiceImpl.java
+++ b/src/main/java/com/danum/danum/service/comment/VillageCommentServiceImpl.java
@@ -2,11 +2,13 @@ package com.danum.danum.service.comment;
 
 import com.danum.danum.domain.board.village.Village;
 import com.danum.danum.domain.comment.village.*;
+import com.danum.danum.domain.notification.Notification;
 import com.danum.danum.exception.ErrorCode;
 import com.danum.danum.exception.custom.CommentException;
 import com.danum.danum.repository.board.VillageRepository;
 import com.danum.danum.repository.comment.VillageCommentRepository;
 import com.danum.danum.service.member.MemberService;
+import com.danum.danum.service.notification.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +24,7 @@ public class VillageCommentServiceImpl implements VillageCommentService {
     private final VillageCommentMapper villageCommentMapper;
     private final VillageRepository villageRepository;
     private final MemberService memberService;
+    private final NotificationService notificationService;
 
     @Override
     @Transactional
@@ -29,6 +32,11 @@ public class VillageCommentServiceImpl implements VillageCommentService {
         validateCommentContent(villageCommentNewDto.getContent());
         VillageComment villageComment = villageCommentMapper.toEntity(villageCommentNewDto);
         villageCommentRepository.save(villageComment);
+
+        Village village = villageComment.getVillage();
+        String content = String.format("새로운 댓글: %s", villageComment.getContent());
+        String link = "/villages/" + village.getId();
+        notificationService.createNotification(village.getMember().getEmail(), content, link, Notification.NotificationType.VILLAGE_COMMENT);
     }
 
     @Override

--- a/src/main/java/com/danum/danum/service/notification/NotificationService.java
+++ b/src/main/java/com/danum/danum/service/notification/NotificationService.java
@@ -1,0 +1,58 @@
+package com.danum.danum.service.notification;
+
+import com.danum.danum.domain.notification.Notification;
+import com.danum.danum.domain.member.Member;
+import com.danum.danum.repository.notification.NotificationRepository;
+import com.danum.danum.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void createNotification(String memberEmail, String content, String link, Notification.NotificationType type) {
+        Member member = memberRepository.findById(memberEmail)
+                .orElseThrow(() -> new RuntimeException("Member not found"));
+
+        Notification notification = Notification.builder()
+                .member(member)
+                .content(content)
+                .link(link)
+                .isRead(false)
+                .createdAt(LocalDateTime.now())
+                .type(type)
+                .build();
+
+        notificationRepository.save(notification);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Notification> getNotifications(String memberEmail) {
+        Member member = memberRepository.findById(memberEmail)
+                .orElseThrow(() -> new RuntimeException("Member not found"));
+        return notificationRepository.findByMemberOrderByCreatedAtDesc(member);
+    }
+
+    @Transactional(readOnly = true)
+    public long getUnreadCount(String memberEmail) {
+        Member member = memberRepository.findById(memberEmail)
+                .orElseThrow(() -> new RuntimeException("Member not found"));
+        return notificationRepository.countByMemberAndIsReadFalse(member);
+    }
+
+    @Transactional
+    public void markAsRead(Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new RuntimeException("Notification not found"));
+        notification.markAsRead();
+    }
+}


### PR DESCRIPTION
향후 새로운 알림 유형 추가가 용이하게 하기위해 별도의 엔티티와 서비스로직을 구현했습니다.

1. 내용, 링크, 읽음 상태, 유형 필드를 가진 Notification 엔티티
2. 데이터베이스 작업을 위한 NotificationRepository
3. 알림 생성, 조회, 읽음 처리 메소드가 있는 NotificationService
4. 알림 조회 및 읽음 처리를 위한 새로운 API 엔드포인트