### PR TITLE
refactor: NotificationDto 도입 및 서비스 로직 수정

### DIFF
--- a/src/main/java/com/danum/danum/controller/board/MainPageController.java
+++ b/src/main/java/com/danum/danum/controller/board/MainPageController.java
@@ -3,6 +3,7 @@ package com.danum.danum.controller;
 import com.danum.danum.domain.board.question.QuestionViewDto;
 import com.danum.danum.domain.board.village.VillageViewDto;
 import com.danum.danum.domain.notification.Notification;
+import com.danum.danum.domain.notification.NotificationDto;
 import com.danum.danum.service.board.question.QuestionService;
 import com.danum.danum.service.board.village.VillageService;
 import com.danum.danum.service.notification.NotificationService;
@@ -64,9 +65,9 @@ public class MainPageController {
     }
 
     @GetMapping("/notifications")
-    public ResponseEntity<List<Notification>> getNotifications(Authentication authentication) {
+    public ResponseEntity<List<NotificationDto>> getNotifications(Authentication authentication) {
         String userEmail = authentication.getName();
-        List<Notification> notifications = notificationService.getNotifications(userEmail);
+        List<NotificationDto> notifications = notificationService.getNotifications(userEmail);
         return ResponseEntity.ok(notifications);
     }
 

--- a/src/main/java/com/danum/danum/domain/notification/NotificationDto.java
+++ b/src/main/java/com/danum/danum/domain/notification/NotificationDto.java
@@ -1,0 +1,32 @@
+package com.danum.danum.domain.notification;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NotificationDto {
+    private Long id;
+    private String content;
+    private String link;
+    private LocalDateTime createdAt;
+    private Notification.NotificationType type;
+    private boolean isRead;
+
+    public static NotificationDto from(Notification notification) {
+        return NotificationDto.builder()
+                .id(notification.getId())
+                .content(notification.getContent())
+                .link(notification.getLink())
+                .createdAt(notification.getCreatedAt())
+                .type(notification.getType())
+                .isRead(notification.isRead())
+                .build();
+    }
+}

--- a/src/main/java/com/danum/danum/service/notification/NotificationService.java
+++ b/src/main/java/com/danum/danum/service/notification/NotificationService.java
@@ -1,6 +1,7 @@
 package com.danum.danum.service.notification;
 
 import com.danum.danum.domain.notification.Notification;
+import com.danum.danum.domain.notification.NotificationDto;
 import com.danum.danum.domain.member.Member;
 import com.danum.danum.repository.notification.NotificationRepository;
 import com.danum.danum.repository.MemberRepository;
@@ -10,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -21,7 +23,7 @@ public class NotificationService {
     @Transactional
     public void createNotification(String memberEmail, String content, String link, Notification.NotificationType type) {
         Member member = memberRepository.findById(memberEmail)
-                .orElseThrow(() -> new RuntimeException("Member not found"));
+                .orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다"));
 
         Notification notification = Notification.builder()
                 .member(member)
@@ -36,23 +38,26 @@ public class NotificationService {
     }
 
     @Transactional(readOnly = true)
-    public List<Notification> getNotifications(String memberEmail) {
+    public List<NotificationDto> getNotifications(String memberEmail) {
         Member member = memberRepository.findById(memberEmail)
-                .orElseThrow(() -> new RuntimeException("Member not found"));
-        return notificationRepository.findByMemberOrderByCreatedAtDesc(member);
+                .orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다"));
+        return notificationRepository.findByMemberOrderByCreatedAtDesc(member)
+                .stream()
+                .map(NotificationDto::from)
+                .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
     public long getUnreadCount(String memberEmail) {
         Member member = memberRepository.findById(memberEmail)
-                .orElseThrow(() -> new RuntimeException("Member not found"));
+                .orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다"));
         return notificationRepository.countByMemberAndIsReadFalse(member);
     }
 
     @Transactional
     public void markAsRead(Long notificationId) {
         Notification notification = notificationRepository.findById(notificationId)
-                .orElseThrow(() -> new RuntimeException("Notification not found"));
+                .orElseThrow(() -> new RuntimeException("알림을 찾을 수 없습니다."));
         notification.markAsRead();
     }
 }


### PR DESCRIPTION
NotificationDto 클래스 신규 생성
   - 알림 정보 전달 시 필요한 데이터만 포함하도록 설계
   - Notification 엔티티로부터 DTO를 생성하는 정적 메소드 구현

NotificationService 클래스 수정
   - getNotifications 메소드의 반환 타입을 List<NotificationDto>로 변경
   - Notification 엔티티를 NotificationDto로 변환하는 로직 추가

 MainPageController 수정 (해당되는 경우)
   - getNotifications 엔드포인트의 반환 타입을 List<NotificationDto>로 변경

사용자의 정보가 노출되던것을 DTO로 필요한 데이터만을 전송함으로써 보안 강화 및 유지 보수성을 높힘