### PR TITLE
feat: 질문/마을 게시글이 채택된지 확인하는 기능

### DIFF
--- a/src/main/java/com/danum/danum/controller/board/QuestionController.java
+++ b/src/main/java/com/danum/danum/controller/board/QuestionController.java
@@ -75,4 +75,9 @@ public class QuestionController {
     public ResponseEntity<List<QuestionViewDto>> getMemberQuestions(@PathVariable("email") String email) {
         return ResponseEntity.ok(adminService.getMemberQuestions(email));
     }
+
+    @GetMapping("/{id}/has-accepted-comment")
+    public ResponseEntity<Boolean> hasAcceptedComment(@PathVariable Long id) {
+        return ResponseEntity.ok(questionService.hasAcceptedComment(id));
+    }
 }

--- a/src/main/java/com/danum/danum/controller/board/VillageController.java
+++ b/src/main/java/com/danum/danum/controller/board/VillageController.java
@@ -104,4 +104,9 @@ public class VillageController {
         Page<VillageViewDto> villages = adminService.getMemberVillages(email, pageable);
         return ResponseEntity.ok(PagedResponseDto.from(villages));
     }
+
+    @GetMapping("/{id}/has-accepted-comment")
+    public ResponseEntity<Boolean> hasAcceptedComment(@PathVariable Long id) {
+        return ResponseEntity.ok(villageService.hasAcceptedComment(id));
+    }
 }

--- a/src/main/java/com/danum/danum/service/board/question/QuestionService.java
+++ b/src/main/java/com/danum/danum/service/board/question/QuestionService.java
@@ -25,4 +25,5 @@ public interface QuestionService {
 
     List<QuestionViewDto> getPopularQuestions(int limit);
 
+    boolean hasAcceptedComment(Long questionId);
 }

--- a/src/main/java/com/danum/danum/service/board/question/QuestionServiceImpl.java
+++ b/src/main/java/com/danum/danum/service/board/question/QuestionServiceImpl.java
@@ -9,6 +9,7 @@ import com.danum.danum.repository.MemberRepository;
 import com.danum.danum.repository.board.QuestionEmailRepository;
 import com.danum.danum.repository.board.QuestionLikeRepository;
 import com.danum.danum.repository.board.QuestionRepository;
+import com.danum.danum.repository.comment.QuestionCommentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -35,6 +36,8 @@ public class QuestionServiceImpl implements QuestionService{
     private final MemberRepository memberRepository;
 
     private final QuestionLikeRepository questionLikeRepository;
+
+    private final QuestionCommentRepository questionCommentRepository;
 
     @Override
     @Transactional
@@ -136,5 +139,12 @@ public class QuestionServiceImpl implements QuestionService{
                 .stream()
                 .map(QuestionViewDto::from)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean hasAcceptedComment(Long questionId) {
+        return questionCommentRepository.existsByQuestionAndIsAcceptedTrue(questionRepository.findById(questionId)
+                .orElseThrow(() -> new BoardException(ErrorCode.BOARD_NOT_FOUND_EXCEPTION)));
     }
 }

--- a/src/main/java/com/danum/danum/service/board/village/VillageService.java
+++ b/src/main/java/com/danum/danum/service/board/village/VillageService.java
@@ -32,4 +32,5 @@ public interface VillageService {
 
     Page<VillageViewDto> getVillagesByPostType(VillagePostType postType, Pageable pageable);
 
+    boolean hasAcceptedComment(Long villageId);
 }

--- a/src/main/java/com/danum/danum/service/board/village/VillageServiceImpl.java
+++ b/src/main/java/com/danum/danum/service/board/village/VillageServiceImpl.java
@@ -12,6 +12,7 @@ import com.danum.danum.repository.MemberRepository;
 import com.danum.danum.repository.board.VillageEmailRepository;
 import com.danum.danum.repository.board.VillageLikeRepository;
 import com.danum.danum.repository.board.VillageRepository;
+import com.danum.danum.repository.comment.VillageCommentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -38,6 +39,8 @@ public class VillageServiceImpl implements VillageService{
     private final VillageLikeRepository villageLikeRepository;
 
     private final MemberRepository memberRepository;
+
+    private final VillageCommentRepository villageCommentRepository;
 
     @Override
     @Transactional
@@ -179,5 +182,10 @@ public class VillageServiceImpl implements VillageService{
         return villagePage.map(this::convertToViewDto);
     }
 
-
+    @Override
+    @Transactional(readOnly = true)
+    public boolean hasAcceptedComment(Long villageId) {
+        return villageCommentRepository.existsByVillageAndIsAcceptedTrue(villageRepository.findById(villageId)
+                .orElseThrow(() -> new BoardException(ErrorCode.BOARD_NOT_FOUND_EXCEPTION)));
+    }
 }


### PR DESCRIPTION
### 변경 사항

QuestionService와 VillageService에 hasAcceptedComment 메소드 추가
QuestionServiceImpl과 VillageServiceImpl에서 해당 메소드 구현
QuestionController와 VillageController에 채택 확인 엔드포인트 추가

기존 리포지토리 메소드(existsByQuestionAndIsAcceptedTrue)를 재사용하여 채택 여부 확인
별도의 API 엔드포인트를 통해 채택 정보 제공

viewDto에 추가하지않은 이유는 
DTO에 추가할 경우 모든 조회 시 채택 정보가 포함되어 불필요한 경우 발생
채택 정보가 필요 없는 경우에도 항상 조회해야 하는 문제 방지

