### PR TITLE
feat: 회원정보에 주소필드 추가 및 업데이트 필드값 추가

### DIFF
--- a/src/main/java/com/danum/danum/domain/member/Member.java
+++ b/src/main/java/com/danum/danum/domain/member/Member.java
@@ -63,6 +63,10 @@ public class Member {
     private Double longitude;
 
     @Getter
+    @Column(name = "address")
+    private String address;
+
+    @Getter
     @Column(name = "profile_image_url")
     private String profileImageUrl;
 
@@ -76,6 +80,15 @@ public class Member {
 
     public void updateUserName(String username) {
         this.name = username;
+    }
+
+    public void updateUserAddress(String address) {
+        this.address = address;
+    }
+
+    public void updateUserLocation(Double latitude, Double longitude) {
+        this.latitude = latitude;
+        this.longitude = longitude;
     }
 
     public void updateProfileImageUrl(String profileImageUrl) {

--- a/src/main/java/com/danum/danum/domain/member/MemberMapper.java
+++ b/src/main/java/com/danum/danum/domain/member/MemberMapper.java
@@ -13,13 +13,13 @@ public class MemberMapper {
                 .name(registerDto.getName())
                 .latitude(registerDto.getLatitude())
                 .longitude(registerDto.getLongitude())
+                .address(registerDto.getAddress())
                 .exp(0)
                 .contribution(0)
                 .role(Role.USER)
                 .joinDateTime(LocalDateTime.now())
                 .profileImageUrl(registerDto.getProfileImageUrl())
                 .build();
-
     }
 
 }

--- a/src/main/java/com/danum/danum/domain/member/RegisterDto.java
+++ b/src/main/java/com/danum/danum/domain/member/RegisterDto.java
@@ -21,6 +21,8 @@ public class RegisterDto {
 
     private Double longitude;
 
+    private String address;
+
     private String profileImageUrl;
 
     public void settingPassword(String password){

--- a/src/main/java/com/danum/danum/domain/member/UpdateDto.java
+++ b/src/main/java/com/danum/danum/domain/member/UpdateDto.java
@@ -19,6 +19,8 @@ public class UpdateDto {
 
     private Double longitude;
 
+    private String address;
+
     private String profileImageUrl;
 
 }

--- a/src/main/java/com/danum/danum/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/danum/danum/service/member/MemberServiceImpl.java
@@ -96,7 +96,10 @@ public class MemberServiceImpl implements MemberService {
         String changePassword = updateDto.getPassword();
         String changePhone = updateDto.getPhone();
         String changeName = updateDto.getName();
-        String changeProfileImageUrl = updateDto.getProfileImageUrl();  // 추가
+        String changeProfileImageUrl = updateDto.getProfileImageUrl();
+        Double changeLatitude = updateDto.getLatitude();
+        Double changeLongitude = updateDto.getLongitude();
+        String changeAddress = updateDto.getAddress();
 
         if (StringUtils.hasText(changePassword)) {
             member.updateUserPassword(
@@ -110,6 +113,12 @@ public class MemberServiceImpl implements MemberService {
         }
         if (StringUtils.hasText(changeProfileImageUrl)) {  // 추가
             member.updateProfileImageUrl(changeProfileImageUrl);
+        }
+        if (changeLatitude != null && changeLongitude != null) {
+            member.updateUserLocation(changeLatitude, changeLongitude);
+        }
+        if (StringUtils.hasText(changeAddress)) {
+            member.updateUserAddress(changeAddress);
         }
 
         return memberRepository.save(member);


### PR DESCRIPTION
이전에는 사용자의 위치정보를 위도, 경도만을 가져왔습니다.
하지만 게시글 필터링할때 위치에서 **시 **구를 통해 게시글 필터링을 예정하고 있어서 
회원 정보에 도로명 주소를 담을 address 필드를 추가하였습니다.

또한 회원의 updateDto에 위치정보를 수정할수 있도록 위도, 경도, 도로명주소를 추가하여 update로직에도 추가하였습니다. 