### PR TITLE
feat: 사용자의 주소를 파싱하여 게시글 태그기능 및 ai 프롬프트에 주소추가

### DIFF
--- a/src/main/java/com/danum/danum/domain/board/question/Question.java
+++ b/src/main/java/com/danum/danum/domain/board/question/Question.java
@@ -54,6 +54,9 @@ public class Question {
     @Column(name = "question_like")
     private Long like;
 
+    @Column(name = "address_tag")
+    private String addressTag;
+
     public void increasedViews() {
         this.view_count++;
     }
@@ -69,5 +72,9 @@ public class Question {
     public void update(String newContent, String newTitle) {
         this.content = newContent;
         this.title = newTitle;
+    }
+
+    public void setAddressTag(String addressTag) {
+        this.addressTag = addressTag;
     }
 }

--- a/src/main/java/com/danum/danum/domain/board/question/QuestionMapper.java
+++ b/src/main/java/com/danum/danum/domain/board/question/QuestionMapper.java
@@ -7,6 +7,7 @@ import com.danum.danum.exception.custom.MemberException;
 import com.danum.danum.exception.custom.OpenAiException;
 import com.danum.danum.repository.MemberRepository;
 import com.danum.danum.repository.ai.OpenAiConversationRepository;
+import com.danum.danum.util.AddressParser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -30,6 +31,7 @@ public class QuestionMapper {
         }
 
         Member member = optionalMember.get();
+        String addressTag = AddressParser.parseAddress(member.getAddress());
 
         Question.QuestionBuilder count = Question.builder()
                 .member(member)
@@ -37,7 +39,8 @@ public class QuestionMapper {
                 .content(questionNewDto.getContent())
                 .created_at(LocalDateTime.now())
                 .view_count(0L)
-                .like(0L);
+                .like(0L)
+                .addressTag(addressTag);
 
         if(questionNewDto.getCreateId() != null) {
             OpenAiConversation conversation = conversationRepository.findById(questionNewDto.getCreateId())

--- a/src/main/java/com/danum/danum/domain/board/question/QuestionViewDto.java
+++ b/src/main/java/com/danum/danum/domain/board/question/QuestionViewDto.java
@@ -31,6 +31,8 @@ public class QuestionViewDto {
 
     private Long like;
 
+    private String addressTag;
+
     public static QuestionViewDto from(Question question) {
         return QuestionViewDto.builder()
                 .question_id(question.getId())
@@ -41,6 +43,7 @@ public class QuestionViewDto {
                 .conversation(question.getConversation())
                 .view_count(question.getView_count())
                 .like(question.getLike())
+                .addressTag(question.getAddressTag())
                 .build();
     }
 

--- a/src/main/java/com/danum/danum/domain/board/village/Village.java
+++ b/src/main/java/com/danum/danum/domain/board/village/Village.java
@@ -51,6 +51,9 @@ public class Village {
     @Column(name = "post_type")
     private VillagePostType postType;
 
+    @Column(name = "address_tag")
+    private String addressTag;
+
     public void increasedViews() {
         this.view_count++;
     }
@@ -71,6 +74,10 @@ public class Village {
     public void update(String newContent, String newTitle) {
         this.content = newContent;
         this.title = newTitle;
+    }
+
+    public void setAddressTag(String addressTag) {
+        this.addressTag = addressTag;
     }
 
 }

--- a/src/main/java/com/danum/danum/domain/board/village/VillageMapper.java
+++ b/src/main/java/com/danum/danum/domain/board/village/VillageMapper.java
@@ -4,6 +4,7 @@ import com.danum.danum.domain.member.Member;
 import com.danum.danum.exception.ErrorCode;
 import com.danum.danum.exception.custom.MemberException;
 import com.danum.danum.repository.MemberRepository;
+import com.danum.danum.util.AddressParser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -25,6 +26,7 @@ public class VillageMapper {
         }
 
         Member member = optionalMember.get();
+        String addressTag = AddressParser.parseAddress(member.getAddress());
 
         return Village.builder()
                 .member(member)
@@ -36,6 +38,7 @@ public class VillageMapper {
                 .view_count(0L)
                 .like(0L)
                 .postType(villageNewDto.getPostType())
+                .addressTag(addressTag)
                 .build();
     }
 }

--- a/src/main/java/com/danum/danum/domain/board/village/VillageViewDto.java
+++ b/src/main/java/com/danum/danum/domain/board/village/VillageViewDto.java
@@ -30,6 +30,8 @@ public class VillageViewDto {
 
     private VillagePostType postType;
 
+    private String addressTag;
+
     public VillageViewDto toEntity(Village village) {
         return VillageViewDto.builder()
                 .village_id(village.getId())
@@ -40,6 +42,7 @@ public class VillageViewDto {
                 .view_count(village.getView_count())
                 .like(village.getLike())
                 .postType(village.getPostType())
+                .addressTag(village.getAddressTag())
                 .build();
     }
 

--- a/src/main/java/com/danum/danum/service/ai/OpenAiServiceImpl.java
+++ b/src/main/java/com/danum/danum/service/ai/OpenAiServiceImpl.java
@@ -41,8 +41,8 @@ public class OpenAiServiceImpl implements OpenAiService {
 
         // 프롬프트에 사용자 위치 정보 추가
         Member member = memberService.getMemberByAuthentication();
-        String userLocation = String.format("사용자의 위치: 위도 %f 경도 %f 이며 이걸 기반으로 한국어로 답장해주세요",
-                member.getLatitude(), member.getLongitude());
+        String userLocation = String.format("사용자의 위치: 위도 %f 경도 %f 이며 주소는 %s 입니다. 이걸 기반으로 한국어로 답장해주세요",
+                member.getLatitude(), member.getLongitude(), member.getAddress());
         promptMessage.add(new UserMessage(userLocation));
 
         // 프롬프트 작성 및 api 응답 반환

--- a/src/main/java/com/danum/danum/util/AddressParser.java
+++ b/src/main/java/com/danum/danum/util/AddressParser.java
@@ -1,0 +1,45 @@
+package com.danum.danum.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class AddressParser {
+
+    private static final Pattern CITY_PATTERN = Pattern.compile("^(서울|부산|대구|인천|광주|대전|울산|세종|경기|강원|충북|충남|전북|전남|경북|경남|제주)(특별시|광역시|특별자치시|도)?");
+    private static final Pattern DISTRICT_PATTERN = Pattern.compile("(\\S+시 )?(\\S+구|\\S+군)");
+
+    public static String parseAddress(String fullAddress) {
+        if (fullAddress == null || fullAddress.isEmpty()) {
+            return "";
+        }
+
+        String city = extractCity(fullAddress);
+        String district = extractDistrict(fullAddress);
+
+        if (city.isEmpty() && district.isEmpty()) {
+            return "";
+        } else if (city.isEmpty()) {
+            return district;
+        } else if (district.isEmpty()) {
+            return city;
+        } else {
+            return city + " " + district;
+        }
+    }
+
+    private static String extractCity(String address) {
+        Matcher matcher = CITY_PATTERN.matcher(address);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        return "";
+    }
+
+    private static String extractDistrict(String address) {
+        Matcher matcher = DISTRICT_PATTERN.matcher(address);
+        if (matcher.find()) {
+            return matcher.group(2);
+        }
+        return "";
+    }
+}


### PR DESCRIPTION
Member에 address 필드에 사용자의 도로명주소를 받아,  도로명주소를 문자열 파싱기능을 하는 AddressParser 통해
서울특별시 동작구 노량진로 **** 에서 서울시 동작구로 문자열 파싱하여, 마을/질문 게시글에 addressTag로써 어디서 작성된 글인지 확인할수 있게 Mapper, viewDto에 추가

AI 프롬프트에서는 이전에 위도, 경도만을 제공하였는데, 이번 사용자의 도로명주소를 ai 프롬프트에 추가함으로써
위치 정보를 구조화하여 AI가 더 쉽게 이해하고 활용할 수 있도록 추가하였음.