### PR TITLE
feat: 마을/질문 게시글 필터링 로직 변경 및 취지에맞는 로직 구현

### DIFF
--- a/src/main/java/com/danum/danum/controller/board/QuestionController.java
+++ b/src/main/java/com/danum/danum/controller/board/QuestionController.java
@@ -80,4 +80,13 @@ public class QuestionController {
     public ResponseEntity<Boolean> hasAcceptedComment(@PathVariable Long id) {
         return ResponseEntity.ok(questionService.hasAcceptedComment(id));
     }
+
+    @GetMapping("/region")
+    public ResponseEntity<PagedResponseDto<QuestionViewDto>> getQuestionsByRegion(
+            @RequestParam(required = false) String city,
+            @RequestParam(required = false) String district,
+            @PageableDefault(size = 10) Pageable pageable) {
+        Page<QuestionViewDto> questionPage = questionService.getQuestionsByRegion(city, district, pageable);
+        return ResponseEntity.ok(PagedResponseDto.from(questionPage));
+    }
 }

--- a/src/main/java/com/danum/danum/controller/board/VillageController.java
+++ b/src/main/java/com/danum/danum/controller/board/VillageController.java
@@ -76,26 +76,6 @@ public class VillageController {
         return ResponseEntity.ok(PagedResponseDto.from(villagePage));
     }
 
-    @GetMapping("/by-distance")
-    public ResponseEntity<PagedResponseDto<VillageViewDto>> getVillagesByDistance(
-            @RequestParam double latitude,
-            @RequestParam double longitude,
-            @RequestParam double distance,
-            @PageableDefault(size = 10) Pageable pageable) {
-        Page<VillageViewDto> villages = villageService.getVillagesByDistance(latitude, longitude, distance, pageable);
-        return ResponseEntity.ok(PagedResponseDto.from(villages));
-    }
-
-    @GetMapping("/by-category")
-    public ResponseEntity<PagedResponseDto<VillageViewDto>> getVillagesByCategory(
-            @RequestParam double latitude,
-            @RequestParam double longitude,
-            @RequestParam String category,
-            @PageableDefault(size = 10) Pageable pageable) {
-        Page<VillageViewDto> villages = villageService.getVillagesByCategory(latitude, longitude, category, pageable);
-        return ResponseEntity.ok(PagedResponseDto.from(villages));
-    }
-
     @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/members/{email}/villages")
     public ResponseEntity<PagedResponseDto<VillageViewDto>> getMemberVillages(
@@ -108,5 +88,13 @@ public class VillageController {
     @GetMapping("/{id}/has-accepted-comment")
     public ResponseEntity<Boolean> hasAcceptedComment(@PathVariable Long id) {
         return ResponseEntity.ok(villageService.hasAcceptedComment(id));
+    }
+
+    @GetMapping("/local")
+    public ResponseEntity<PagedResponseDto<VillageViewDto>> getLocalVillages(
+            @PageableDefault(size = 10) Pageable pageable) {
+        String userEmail = getLoginUser();
+        Page<VillageViewDto> villages = villageService.getLocalVillages(userEmail, pageable);
+        return ResponseEntity.ok(PagedResponseDto.from(villages));
     }
 }

--- a/src/main/java/com/danum/danum/repository/board/QuestionRepository.java
+++ b/src/main/java/com/danum/danum/repository/board/QuestionRepository.java
@@ -2,13 +2,12 @@ package com.danum.danum.repository.board;
 
 import com.danum.danum.domain.board.question.Question;
 import com.danum.danum.domain.member.Member;
-import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -17,4 +16,7 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
 
     @Query("SELECT q FROM Question q ORDER BY q.view_count DESC")
     List<Question> findPopularQuestions(Pageable pageable);
+
+    Page<Question> findByAddressTagStartingWith(String addressTag, Pageable pageable);
+
 }

--- a/src/main/java/com/danum/danum/repository/board/VillageRepository.java
+++ b/src/main/java/com/danum/danum/repository/board/VillageRepository.java
@@ -15,37 +15,10 @@ import java.util.List;
 
 @Repository
 public interface VillageRepository extends JpaRepository<Village, Long> {
-
-    @Query("SELECT v FROM Village v WHERE " +
-            "6371 * acos(cos(radians(:latitude)) * cos(radians(v.latitude)) * cos(radians(v.longitude) - radians(:longitude)) + sin(radians(:latitude)) * sin(radians(v.latitude))) <= :distance")
-    Page<Village> findVillagesWithinDistance(
-            @Param("latitude") double latitude,
-            @Param("longitude") double longitude,
-            @Param("distance") double distance,
-            Pageable pageable);
-
-    @Query("SELECT v FROM Village v WHERE " +
-            "6371 * acos(cos(radians(:latitude)) * cos(radians(v.latitude)) * cos(radians(v.longitude) - radians(:longitude)) + sin(radians(:latitude)) * sin(radians(v.latitude))) BETWEEN :minDistance AND :maxDistance")
-    Page<Village> findVillagesBetweenDistances(
-            @Param("latitude") double latitude,
-            @Param("longitude") double longitude,
-            @Param("minDistance") double minDistance,
-            @Param("maxDistance") double maxDistance,
-            Pageable pageable);
-
-    @Query("SELECT v FROM Village v WHERE " +
-            "6371 * acos(cos(radians(:latitude)) * cos(radians(v.latitude)) * cos(radians(v.longitude) - radians(:longitude)) + sin(radians(:latitude)) * sin(radians(v.latitude))) > :distance")
-    Page<Village> findVillagesBeyondDistance(
-            @Param("latitude") double latitude,
-            @Param("longitude") double longitude,
-            @Param("distance") double distance,
-            Pageable pageable);
-
     Page<Village> findAllByMember(Member member, Pageable pageable);
+    Page<Village> findByPostType(VillagePostType postType, Pageable pageable);
+    Page<Village> findByAddressTagStartingWith(String addressTag, Pageable pageable);
 
     @Query("SELECT v FROM Village v ORDER BY v.view_count DESC")
     List<Village> findPopularVillages(Pageable pageable);
-
-    Page<Village> findByPostType(VillagePostType postType, Pageable pageable);
-
 }

--- a/src/main/java/com/danum/danum/service/board/question/QuestionService.java
+++ b/src/main/java/com/danum/danum/service/board/question/QuestionService.java
@@ -26,4 +26,6 @@ public interface QuestionService {
     List<QuestionViewDto> getPopularQuestions(int limit);
 
     boolean hasAcceptedComment(Long questionId);
+
+    Page<QuestionViewDto> getQuestionsByRegion(String city, String district, Pageable pageable);
 }

--- a/src/main/java/com/danum/danum/service/board/village/VillageService.java
+++ b/src/main/java/com/danum/danum/service/board/village/VillageService.java
@@ -20,10 +20,6 @@ public interface VillageService {
 
     void likeStatus(Long id, String email);
 
-    Page<VillageViewDto> getVillagesByDistance(double latitude, double longitude, double distance, Pageable pageable);
-
-    Page<VillageViewDto> getVillagesByCategory(double latitude, double longitude, String category, Pageable pageable);
-
     void deleteVillage(Long id);
 
     void update(VillageUpdateDto villageUpdateDto, String loginUser);
@@ -33,4 +29,7 @@ public interface VillageService {
     Page<VillageViewDto> getVillagesByPostType(VillagePostType postType, Pageable pageable);
 
     boolean hasAcceptedComment(Long villageId);
+
+    Page<VillageViewDto> getLocalVillages(String userEmail, Pageable pageable);
+
 }


### PR DESCRIPTION
이전 사용자의 위치정보(위도, 경도)를 통해 하버사인 공식을 통한 게시글 필터링 로직을 SQL 쿼리를 통해 실행되다보니
요청및 효율성이 낮았습니다 이것을 개선하기위해,

지금은 사용자에게 위치정보(위도, 경도, 도로명주소)를 받아 도로명 주소를 AddressParser를 통해 주소 문자열 파싱을 통해
도로명주소를 **시 **구로 잘라 사용자가 게시글을 작성할때 태그 기능으로써 어디서 작성한지 큰틀로 볼수있습니다.
이걸통해 사용자가 서울 동작에서 살고있다면 이번 구현한 /local 주소를 통해 자신의 지역의 글을 확인할수 있습니다.

또한 질문게시판에서 자신이 원하는 지역에 가고싶다면 프론트단에서 **시 **구 까지 설정하여 /region 이라는 api주소와 지정한 쿼리 파라미터를 통해 지역을 설정하여, 해당 지역의 글을 확인할수 있습니다.