### PR TITLE
refactor: 채팅 서비스 로직 분리 및 알림 기능 구현

### DIFF
--- a/src/main/java/com/danum/danum/controller/chat/ChatController.java
+++ b/src/main/java/com/danum/danum/controller/chat/ChatController.java
@@ -1,64 +1,37 @@
 package com.danum.danum.controller.chat;
 
 import com.danum.danum.domain.chat.ChatMessage;
-import com.danum.danum.domain.chat.ChatRoom;
-import com.danum.danum.repository.ChatRoomRepository;
 import com.danum.danum.service.chat.ChatService;
-import com.danum.danum.service.chat.RedisPublisher;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.security.core.Authentication;
-import org.springframework.stereotype.Controller;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Slf4j
 @RequiredArgsConstructor
 @RestController
 public class ChatController {
-
-    private final RedisPublisher redisPublisher;
-    private final ChatRoomRepository chatRoomRepository;
-    private final SimpMessageSendingOperations messagingTemplate;
     private final ChatService chatService;
+    private final SimpMessageSendingOperations messagingTemplate;
 
     @MessageMapping("/chat/message")
     public void message(@Payload ChatMessage message) {
-        ChatRoom chatRoom = chatRoomRepository.findRoomById(message.getRoomId());
-
-        if (chatRoom == null) {
-            return; // 채팅방이 존재하지 않으면 메시지 처리하지 않음
+        try {
+            chatService.processMessage(message);
+        } catch (IllegalArgumentException e) {
+            log.error("Failed to process message: {}", e.getMessage());
         }
-
-        if (chatRoom.isOneToOne() && !chatRoom.isValidOneToOneParticipant(message.getSender())) {
-            return; // 1:1 채팅방에 유효한 참여자가 아니면 메시지 처리하지 않음
-        }
-
-        if (ChatMessage.MessageType.ENTER.equals(message.getType())) {
-            chatRoomRepository.enterChatRoom(message.getRoomId());
-            message.setMessage(message.getSender() + "님이 입장하셨습니다.");
-
-            // 채팅방에 입장할 때 기존 메시지들을 WebSocket으로 전송
-            List<ChatMessage> previousMessages = chatRoomRepository.getMessages(message.getRoomId());
-            for (Object prevMsg : previousMessages) {
-                if (prevMsg instanceof ChatMessage) {
-                    messagingTemplate.convertAndSend("/sub/chat/room/" + message.getRoomId(), prevMsg);
-                }
-            }
-        }
-
-        // Websocket에 발행된 메시지를 Redis로 발행한다(publish)
-        redisPublisher.publish(chatRoomRepository.getTopic(message.getRoomId()), message);
     }
 
     @GetMapping("/main/message")
     public String mainPage(Model model, Authentication authentication) {
-        // 최근 대화 내역을 반환하는 로직
         if (authentication != null && authentication.isAuthenticated()) {
             String email = authentication.getName();
             List<ChatMessage> recentMessages = chatService.getRecentMessages(email);

--- a/src/main/java/com/danum/danum/controller/chat/ChatRoomController.java
+++ b/src/main/java/com/danum/danum/controller/chat/ChatRoomController.java
@@ -5,6 +5,7 @@ import com.danum.danum.domain.chat.ChatRoom;
 import com.danum.danum.repository.ChatRoomRepository;
 import com.danum.danum.service.chat.ChatService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -13,41 +14,33 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.Map;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/chat")
 public class ChatRoomController {
-
-    private final ChatRoomRepository chatRoomRepository;
     private final ChatService chatService;
 
-    // 채팅방 목록 화면
     @GetMapping("/room")
     public String rooms() {
         return "/chat/room";
     }
 
-    // 사용자의 모든 채팅방 목록 조회
     @GetMapping("/rooms")
     public List<ChatRoom> rooms(Authentication authentication) {
-        String userId = authentication.getName();
-        return chatRoomRepository.findRoomsByUserId(userId);
+        return chatService.findRoomsByUserId(authentication.getName());
     }
 
-    // 새로운 채팅방 생성
     @PostMapping("/room")
     public ChatRoom createRoom(@RequestBody String name, Authentication authentication) {
-        String userId = authentication.getName();
-        return chatRoomRepository.createChatRoom(name, userId);
+        return chatService.createChatRoom(name, authentication.getName());
     }
 
-    // 특정 채팅방 정보 조회
     @GetMapping("/room/{roomId}")
     public ChatRoom roomInfo(@PathVariable String roomId) {
-        return chatRoomRepository.findRoomById(roomId);
+        return chatService.findRoomById(roomId);
     }
 
-    // 1:1 채팅방 생성
     @PostMapping("/room/one-to-one")
     public ResponseEntity<?> createOneToOneChat(
             @RequestBody Map<String, String> payload,
@@ -59,53 +52,43 @@ public class ChatRoomController {
             return ResponseEntity.badRequest().body("targetUserId is required");
         }
 
-        if (currentUserId.equals(targetUserId)) {
-            return ResponseEntity.badRequest().body("자신과 채팅을 시작할 수 없습니다");
+        try {
+            ChatRoom chatRoom = chatService.createOneToOneChatRoom(currentUserId, targetUserId, "1:1 채팅");
+            return ResponseEntity.ok().body(Map.of("roomId", chatRoom.getRoomId()));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
         }
-
-        ChatRoom chatRoom = chatRoomRepository.findOrCreateOneToOneChatRoom(currentUserId, targetUserId, "1:1 채팅");
-
-        return ResponseEntity.ok().body(Map.of("roomId", chatRoom.getRoomId()));
     }
 
-    // 채팅방 입장 및 이전 메시지 로드
     @GetMapping("/room/{roomId}/enter")
     public ResponseEntity<?> enterRoom(@PathVariable String roomId, Authentication authentication) {
-        String userId = authentication.getName();
-        ChatRoom chatRoom = chatRoomRepository.findRoomById(roomId);
+        try {
+            String userId = authentication.getName();
+            ChatRoom chatRoom = chatService.findRoomById(roomId);
 
-        if (chatRoom == null) {
-            return ResponseEntity.notFound().build();
+            if (chatRoom == null) {
+                return ResponseEntity.notFound().build();
+            }
+
+            chatService.enterChatRoom(roomId);
+            List<ChatMessage> messages = chatService.getRoomMessages(roomId);
+
+            return ResponseEntity.ok().body(Map.of(
+                    "roomInfo", chatRoom,
+                    "messages", messages
+            ));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
         }
-
-        if (chatRoom.isOneToOne() && !chatRoom.isValidOneToOneParticipant(userId)) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("이 1:1 채팅방에 참여할 권한이 없습니다.");
-        }
-
-        if (!chatRoom.isOneToOne() && !chatRoom.isParticipant(userId)) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("이 채팅방에 참여할 권한이 없습니다.");
-        }
-
-        List<ChatMessage> messages = chatRoomRepository.getMessages(roomId);
-        chatRoomRepository.enterChatRoom(roomId);
-
-        return ResponseEntity.ok().body(Map.of(
-                "roomInfo", chatRoom,
-                "messages", messages
-        ));
     }
 
-    // 최근 대화 내역 조회
     @GetMapping("/recent-messages")
     public List<ChatMessage> getRecentMessages(Authentication authentication) {
-        String email = authentication.getName();
-        return chatService.getRecentMessages(email);
+        return chatService.getRecentMessages(authentication.getName());
     }
 
-    // 채팅방 메시지 조회
-    // 채팅방 메시지 조회
     @GetMapping("/room/{roomId}/messages")
     public List<ChatMessage> getRoomMessages(@PathVariable String roomId) {
-        return chatRoomRepository.getMessages(roomId);
+        return chatService.getRoomMessages(roomId);
     }
 }

--- a/src/main/java/com/danum/danum/domain/notification/Notification.java
+++ b/src/main/java/com/danum/danum/domain/notification/Notification.java
@@ -38,15 +38,25 @@ public class Notification {
     private LocalDateTime createdAt;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = false, length = 50)
     private NotificationType type;
+
+    @Column(name = "room_id")
+    private String roomId;
 
     public void markAsRead() {
         this.isRead = true;
     }
 
+    public void updateContent(String newContent) {
+        this.content = newContent;
+        this.createdAt = LocalDateTime.now();  // 시간도 업데이트
+    }
+
     public enum NotificationType {
         QUESTION_COMMENT,
-        VILLAGE_COMMENT
+        VILLAGE_COMMENT,
+        CHAT_MESSAGE,
+        CHAT_ROOM_INVITE
     }
 }

--- a/src/main/java/com/danum/danum/repository/ChatRoomRepository.java
+++ b/src/main/java/com/danum/danum/repository/ChatRoomRepository.java
@@ -2,216 +2,25 @@ package com.danum.danum.repository;
 
 import com.danum.danum.domain.chat.ChatMessage;
 import com.danum.danum.domain.chat.ChatRoom;
-import com.danum.danum.service.chat.RedisSubscriber;
-import jakarta.annotation.PostConstruct;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.HashOperations;
-import org.springframework.data.redis.core.ListOperations;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.ChannelTopic;
-import org.springframework.data.redis.listener.RedisMessageListenerContainer;
-import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.List;
+import java.util.Set;
 
-@Slf4j
-@RequiredArgsConstructor
 @Repository
-public class ChatRoomRepository {
-
-    private final RedisMessageListenerContainer redisMessageListener;
-    private final RedisSubscriber redisSubscriber;
-    private final RedisTemplate<String, Object> redisTemplate;
-
-    private static final String CHAT_ROOMS = "CHAT_ROOM";
-    private static final String CHAT_ROOM_USERS = "CHAT_ROOM_USERS";
-    private static final String USER_CHAT_ROOMS = "USER_CHAT_ROOMS";
-    private static final String CHAT_MESSAGES = "CHAT_MESSAGES";
-    private static final String ONE_TO_ONE_CHAT_ROOMS = "ONE_TO_ONE_CHAT_ROOMS";
-
-    private HashOperations<String, String, ChatRoom> opsHashChatRoom;
-    private HashOperations<String, String, Set<String>> opsHashChatRoomUsers;
-    private HashOperations<String, String, Set<String>> opsHashUserChatRooms;
-    private ListOperations<String, Object> opsListChatMessages;
-
-    private Map<String, ChannelTopic> topics;
-
-    @PostConstruct
-    private void init() {
-        // Redis operations 초기화
-        opsHashChatRoom = redisTemplate.opsForHash();
-        opsHashChatRoomUsers = redisTemplate.opsForHash();
-        opsHashUserChatRooms = redisTemplate.opsForHash();
-        opsListChatMessages = redisTemplate.opsForList();
-        topics = new HashMap<>();
-    }
-
-    //모든 채팅방 조회
-    public List<ChatRoom> findAllRoom() {
-        return opsHashChatRoom.values(CHAT_ROOMS);
-    }
-
-    // ID로 채팅방 조회
-    public ChatRoom findRoomById(String id) {
-        return opsHashChatRoom.get(CHAT_ROOMS, id);
-    }
-
-    //새 채팅방 생성
-    public ChatRoom createChatRoom(String name, String userId) {
-        ChatRoom chatRoom = ChatRoom.create(name);
-        opsHashChatRoom.put(CHAT_ROOMS, chatRoom.getRoomId(), chatRoom);
-        addUserToChatRoom(userId, chatRoom.getRoomId());
-        return chatRoom;
-    }
-
-    // 채팅방에 사용자 추가
-    public void addUserToChatRoom(String userId, String roomId) {
-        // 채팅방의 사용자 목록에 사용자 추가
-        Set<String> users = opsHashChatRoomUsers.get(CHAT_ROOM_USERS, roomId);
-        if (users == null) {
-            users = new HashSet<>();
-        }
-        users.add(userId);
-        opsHashChatRoomUsers.put(CHAT_ROOM_USERS, roomId, users);
-
-        // 사용자의 채팅방 목록에 채팅방 추가
-        Set<String> rooms = opsHashUserChatRooms.get(USER_CHAT_ROOMS, userId);
-        if (rooms == null) {
-            rooms = new HashSet<>();
-        }
-        rooms.add(roomId);
-        opsHashUserChatRooms.put(USER_CHAT_ROOMS, userId, rooms);
-    }
-
-    // 채팅방에서 사용자 제거
-    public void removeUserFromChatRoom(String userId, String roomId) {
-        Set<String> users = opsHashChatRoomUsers.get(CHAT_ROOM_USERS, roomId);
-        if (users != null) {
-            users.remove(userId);
-            opsHashChatRoomUsers.put(CHAT_ROOM_USERS, roomId, users);
-        }
-
-        Set<String> rooms = opsHashUserChatRooms.get(USER_CHAT_ROOMS, userId);
-        if (rooms != null) {
-            rooms.remove(roomId);
-            opsHashUserChatRooms.put(USER_CHAT_ROOMS, userId, rooms);
-        }
-    }
-
-    // 사용자가 참여한 모든 채팅방 조회
-    public List<ChatRoom> findRoomsByUserId(String userId) {
-        Set<String> roomIds = opsHashUserChatRooms.get(USER_CHAT_ROOMS, userId);
-        if (roomIds == null) {
-            return new ArrayList<>();
-        }
-        return roomIds.stream()
-                .map(this::findRoomById)
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
-    }
-
-    // 채팅방 입장 처리
-    public void enterChatRoom(String roomId) {
-        ChannelTopic topic = topics.get(roomId);
-        if (topic == null) {
-            topic = new ChannelTopic(roomId);
-            redisMessageListener.addMessageListener(redisSubscriber, topic);
-            topics.put(roomId, topic);
-        }
-    }
-
-    // 채팅방의 Topic 가져오기 (없으면 생성)
-    public ChannelTopic getTopic(String roomId) {
-        return topics.computeIfAbsent(roomId, k -> {
-            ChannelTopic topic = new ChannelTopic(roomId);
-            redisMessageListener.addMessageListener(redisSubscriber, topic);
-            return topic;
-        });
-    }
-
-    // 채팅 메시지 저장
-    public void saveChatMessage(ChatMessage message) {
-        if (message.getTimestamp() == null) {
-            message.setTimestamp(LocalDateTime.now());
-        }
-
-        // ChatMessage 클래스 직렬화
-        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(ChatMessage.class));
-
-        // list로 redis에 저장
-        redisTemplate.opsForList().rightPush(getChatMessagesKey(message.getRoomId()), message);
-
-        log.info("Saved chat message: {}", message);
-    }
-
-    // 채팅방의 모든 메시지 조회
-    public List<ChatMessage> getMessages(String roomId) {
-        // ChatMessage 클래스 직렬화
-        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(ChatMessage.class));
-
-        List<Object> messages = redisTemplate.opsForList().range(getChatMessagesKey(roomId), 0, -1);
-        return messages.stream()
-                .map(msg -> (ChatMessage) msg)
-                .collect(Collectors.toList());
-    }
-
-    // 채팅 메시지 키 생성
-    private String getChatMessagesKey(String roomId) {
-        return CHAT_MESSAGES + "_" + roomId;
-    }
-
-    // 사용자의 최근 메시지 조회
-    public List<ChatMessage> getRecentMessages(String email) {
-        Set<String> userRooms = opsHashUserChatRooms.get(USER_CHAT_ROOMS, email);
-        if (userRooms == null) {
-            return new ArrayList<>();
-        }
-        return userRooms.stream()
-                .map(roomId -> {
-                    List<ChatMessage> messages = getMessages(roomId);
-                    if (!messages.isEmpty()) {
-                        return messages.get(messages.size() - 1);
-                    }
-                    return null;
-                })
-                .filter(Objects::nonNull)
-                .sorted((m1, m2) -> {
-                    LocalDateTime t1 = m1.getTimestamp();
-                    LocalDateTime t2 = m2.getTimestamp();
-                    if (t1 == null && t2 == null) return 0;
-                    if (t1 == null) return 1;
-                    if (t2 == null) return -1;
-                    return t2.compareTo(t1);
-                })
-                .collect(Collectors.toList());
-    }
-
-
-    // 1:1 채팅방 찾기 또는 생성
-    public ChatRoom findOrCreateOneToOneChatRoom(String user1, String user2, String name) {
-        String key = getOneToOneChatKey(user1, user2);
-        String roomId = (String) redisTemplate.opsForHash().get(ONE_TO_ONE_CHAT_ROOMS, key);
-
-        if (roomId != null) {
-            return findRoomById(roomId);
-        }
-
-        ChatRoom chatRoom = ChatRoom.createOneToOne(name, user1, user2);
-        opsHashChatRoom.put(CHAT_ROOMS, chatRoom.getRoomId(), chatRoom);
-        redisTemplate.opsForHash().put(ONE_TO_ONE_CHAT_ROOMS, key, chatRoom.getRoomId());
-
-        addUserToChatRoom(user1, chatRoom.getRoomId());
-        addUserToChatRoom(user2, chatRoom.getRoomId());
-
-        return chatRoom;
-    }
-
-    // 1:1 채팅방 키 생성
-    private String getOneToOneChatKey(String user1, String user2) {
-        return user1.compareTo(user2) < 0 ? user1 + ":" + user2 : user2 + ":" + user1;
-    }
+public interface ChatRoomRepository {
+    List<ChatRoom> findAllRoom();
+    ChatRoom findRoomById(String id);
+    ChatRoom createChatRoom(String name, String userId);
+    void addUserToChatRoom(String userId, String roomId);
+    void removeUserFromChatRoom(String userId, String roomId);
+    List<ChatRoom> findRoomsByUserId(String userId);
+    void enterChatRoom(String roomId);
+    ChannelTopic getTopic(String roomId);
+    void saveChatMessage(ChatMessage message);
+    List<ChatMessage> getMessages(String roomId);
+    List<ChatMessage> getRecentMessages(String email);
+    ChatRoom findOrCreateOneToOneChatRoom(String user1, String user2, String name);
+    Set<String> getUsersInRoom(String roomId);
 }

--- a/src/main/java/com/danum/danum/repository/RedisChatRoomRepository.java
+++ b/src/main/java/com/danum/danum/repository/RedisChatRoomRepository.java
@@ -1,0 +1,202 @@
+package com.danum.danum.repository;
+
+import com.danum.danum.domain.chat.ChatMessage;
+import com.danum.danum.domain.chat.ChatRoom;
+import com.danum.danum.service.chat.RedisSubscriber;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class RedisChatRoomRepository implements ChatRoomRepository {
+
+    private final RedisMessageListenerContainer redisMessageListener;
+    private final RedisSubscriber redisSubscriber;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    private static final String CHAT_ROOMS = "CHAT_ROOM";
+    private static final String CHAT_ROOM_USERS = "CHAT_ROOM_USERS";
+    private static final String USER_CHAT_ROOMS = "USER_CHAT_ROOMS";
+    private static final String CHAT_MESSAGES = "CHAT_MESSAGES";
+    private static final String ONE_TO_ONE_CHAT_ROOMS = "ONE_TO_ONE_CHAT_ROOMS";
+
+    private HashOperations<String, String, ChatRoom> opsHashChatRoom;
+    private HashOperations<String, String, Set<String>> opsHashChatRoomUsers;
+    private HashOperations<String, String, Set<String>> opsHashUserChatRooms;
+    private ListOperations<String, Object> opsListChatMessages;
+    private Map<String, ChannelTopic> topics;
+
+    @PostConstruct
+    private void init() {
+        opsHashChatRoom = redisTemplate.opsForHash();
+        opsHashChatRoomUsers = redisTemplate.opsForHash();
+        opsHashUserChatRooms = redisTemplate.opsForHash();
+        opsListChatMessages = redisTemplate.opsForList();
+        topics = new HashMap<>();
+    }
+
+    @Override
+    public List<ChatRoom> findAllRoom() {
+        return opsHashChatRoom.values(CHAT_ROOMS);
+    }
+
+    @Override
+    public ChatRoom findRoomById(String id) {
+        return opsHashChatRoom.get(CHAT_ROOMS, id);
+    }
+
+    @Override
+    public ChatRoom createChatRoom(String name, String userId) {
+        ChatRoom chatRoom = ChatRoom.create(name);
+        opsHashChatRoom.put(CHAT_ROOMS, chatRoom.getRoomId(), chatRoom);
+        addUserToChatRoom(userId, chatRoom.getRoomId());
+        return chatRoom;
+    }
+
+    @Override
+    public void addUserToChatRoom(String userId, String roomId) {
+        Set<String> users = getUsersInRoom(roomId);
+        users.add(userId);
+        opsHashChatRoomUsers.put(CHAT_ROOM_USERS, roomId, users);
+
+        Set<String> rooms = getUserRooms(userId);
+        rooms.add(roomId);
+        opsHashUserChatRooms.put(USER_CHAT_ROOMS, userId, rooms);
+    }
+
+    @Override
+    public void removeUserFromChatRoom(String userId, String roomId) {
+        Set<String> users = getUsersInRoom(roomId);
+        users.remove(userId);
+        opsHashChatRoomUsers.put(CHAT_ROOM_USERS, roomId, users);
+
+        Set<String> rooms = getUserRooms(userId);
+        rooms.remove(roomId);
+        opsHashUserChatRooms.put(USER_CHAT_ROOMS, userId, rooms);
+    }
+
+    @Override
+    public List<ChatRoom> findRoomsByUserId(String userId) {
+        Set<String> roomIds = getUserRooms(userId);
+        return roomIds.stream()
+                .map(this::findRoomById)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void enterChatRoom(String roomId) {
+        ChannelTopic topic = topics.get(roomId);
+        if (topic == null) {
+            topic = new ChannelTopic(roomId);
+            redisMessageListener.addMessageListener(redisSubscriber, topic);
+            topics.put(roomId, topic);
+        }
+    }
+
+    @Override
+    public ChannelTopic getTopic(String roomId) {
+        return topics.computeIfAbsent(roomId, k -> {
+            ChannelTopic topic = new ChannelTopic(roomId);
+            redisMessageListener.addMessageListener(redisSubscriber, topic);
+            return topic;
+        });
+    }
+
+    @Override
+    public void saveChatMessage(ChatMessage message) {
+        if (message.getTimestamp() == null) {
+            message.setTimestamp(LocalDateTime.now());
+        }
+
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(ChatMessage.class));
+        redisTemplate.opsForList().rightPush(getChatMessagesKey(message.getRoomId()), message);
+
+        log.info("Saved chat message: {}", message);
+    }
+
+    @Override
+    public List<ChatMessage> getMessages(String roomId) {
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(ChatMessage.class));
+        List<Object> messages = redisTemplate.opsForList().range(getChatMessagesKey(roomId), 0, -1);
+        return messages.stream()
+                .map(msg -> (ChatMessage) msg)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<ChatMessage> getRecentMessages(String email) {
+        Set<String> userRooms = getUserRooms(email);
+        return userRooms.stream()
+                .map(roomId -> {
+                    List<ChatMessage> messages = getMessages(roomId);
+                    if (!messages.isEmpty()) {
+                        return messages.get(messages.size() - 1);
+                    }
+                    return null;
+                })
+                .filter(Objects::nonNull)
+                .sorted((m1, m2) -> {
+                    LocalDateTime t1 = m1.getTimestamp();
+                    LocalDateTime t2 = m2.getTimestamp();
+                    if (t1 == null && t2 == null) return 0;
+                    if (t1 == null) return 1;
+                    if (t2 == null) return -1;
+                    return t2.compareTo(t1);
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public ChatRoom findOrCreateOneToOneChatRoom(String user1, String user2, String name) {
+        String key = getOneToOneChatKey(user1, user2);
+        String roomId = (String) redisTemplate.opsForHash().get(ONE_TO_ONE_CHAT_ROOMS, key);
+
+        if (roomId != null) {
+            return findRoomById(roomId);
+        }
+
+        ChatRoom chatRoom = ChatRoom.createOneToOne(name, user1, user2);
+        opsHashChatRoom.put(CHAT_ROOMS, chatRoom.getRoomId(), chatRoom);
+        redisTemplate.opsForHash().put(ONE_TO_ONE_CHAT_ROOMS, key, chatRoom.getRoomId());
+
+        addUserToChatRoom(user1, chatRoom.getRoomId());
+        addUserToChatRoom(user2, chatRoom.getRoomId());
+
+        return chatRoom;
+    }
+
+    @Override
+    public Set<String> getUsersInRoom(String roomId) {
+        return Optional.ofNullable(opsHashChatRoomUsers.get(CHAT_ROOM_USERS, roomId))
+                .orElse(new HashSet<>());
+    }
+
+    private Set<String> getUserRooms(String userId) {
+        return Optional.ofNullable(opsHashUserChatRooms.get(USER_CHAT_ROOMS, userId))
+                .orElse(new HashSet<>());
+    }
+
+    private String getOneToOneChatKey(String user1, String user2) {
+        List<String> users = Arrays.asList(user1, user2);
+        Collections.sort(users);
+        return String.join(":", users);
+    }
+
+    private String getChatMessagesKey(String roomId) {
+        return CHAT_MESSAGES + "_" + roomId;
+    }
+}

--- a/src/main/java/com/danum/danum/repository/notification/NotificationRepository.java
+++ b/src/main/java/com/danum/danum/repository/notification/NotificationRepository.java
@@ -2,13 +2,25 @@ package com.danum.danum.repository.notification;
 
 import com.danum.danum.domain.notification.Notification;
 import com.danum.danum.domain.member.Member;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     List<Notification> findByMemberOrderByCreatedAtDesc(Member member);
     long countByMemberAndIsReadFalse(Member member);
+
+    @Query("SELECT n FROM Notification n WHERE n.member.email = :memberEmail " +
+            "AND n.roomId = :roomId AND n.type = :type AND n.isRead = false " +
+            "ORDER BY n.createdAt DESC")
+    List<Notification> findUnreadByMemberEmailAndRoomIdAndType(
+            @Param("memberEmail") String memberEmail,
+            @Param("roomId") String roomId,
+            @Param("type") Notification.NotificationType type
+    );
 }

--- a/src/main/java/com/danum/danum/service/chat/ChatService.java
+++ b/src/main/java/com/danum/danum/service/chat/ChatService.java
@@ -1,24 +1,31 @@
 package com.danum.danum.service.chat;
 
 import com.danum.danum.domain.chat.ChatMessage;
-import com.danum.danum.repository.ChatRoomRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
+import com.danum.danum.domain.chat.ChatRoom;
+import org.springframework.data.redis.listener.ChannelTopic;
 import java.util.List;
+import java.util.Set;
 
-@Service
-@RequiredArgsConstructor
-public class ChatService {
+public interface ChatService {
+    // 채팅방 관련
+    List<ChatRoom> findAllRooms();
+    ChatRoom findRoomById(String roomId);
+    ChatRoom createChatRoom(String name, String userId);
+    List<ChatRoom> findRoomsByUserId(String userId);
+    void addUserToChatRoom(String userId, String roomId);
+    void removeUserFromChatRoom(String userId, String roomId);
+    Set<String> getUsersInRoom(String roomId);
 
-    private final ChatRoomRepository chatRoomRepository;
+    // 메시지 관련
+    void saveChatMessage(ChatMessage message);
+    List<ChatMessage> getRoomMessages(String roomId);
+    List<ChatMessage> getRecentMessages(String email);
+    void processMessage(ChatMessage message);
 
-    /**
-     * 사용자의 최근 대화 내역을 조회기능
-     * @param email 사용자 이메일
-     * @return 최근 대화 내역 목록
-     */
-    public List<ChatMessage> getRecentMessages(String email) {
-        return chatRoomRepository.getRecentMessages(email);
-    }
+    // 1:1 채팅
+    ChatRoom createOneToOneChatRoom(String currentUserId, String targetUserId, String name);
+
+    // 채팅방 참여
+    void enterChatRoom(String roomId);
+    ChannelTopic getTopic(String roomId);
 }

--- a/src/main/java/com/danum/danum/service/chat/ChatServiceImpl.java
+++ b/src/main/java/com/danum/danum/service/chat/ChatServiceImpl.java
@@ -1,0 +1,226 @@
+package com.danum.danum.service.chat;
+
+import com.danum.danum.domain.chat.ChatMessage;
+import com.danum.danum.domain.chat.ChatRoom;
+import com.danum.danum.domain.member.Member;
+import com.danum.danum.domain.notification.Notification;
+import com.danum.danum.repository.ChatRoomRepository;
+import com.danum.danum.repository.MemberRepository;
+import com.danum.danum.repository.notification.NotificationRepository;
+import com.danum.danum.service.notification.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatServiceImpl implements ChatService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final RedisPublisher redisPublisher;
+    private final NotificationService notificationService;
+    private final NotificationRepository notificationRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public List<ChatRoom> findAllRooms() {
+        return chatRoomRepository.findAllRoom();
+    }
+
+    @Override
+    public ChatRoom findRoomById(String roomId) {
+        return chatRoomRepository.findRoomById(roomId);
+    }
+
+    @Override
+    public ChatRoom createChatRoom(String name, String userId) {
+        log.info("Creating new chat room: {} for user: {}", name, userId);
+        return chatRoomRepository.createChatRoom(name, userId);
+    }
+
+    @Override
+    public List<ChatRoom> findRoomsByUserId(String userId) {
+        return chatRoomRepository.findRoomsByUserId(userId);
+    }
+
+    @Override
+    public void addUserToChatRoom(String userId, String roomId) {
+        log.info("Adding user: {} to room: {}", userId, roomId);
+        chatRoomRepository.addUserToChatRoom(userId, roomId);
+    }
+
+    @Override
+    public void removeUserFromChatRoom(String userId, String roomId) {
+        log.info("Removing user: {} from room: {}", userId, roomId);
+        chatRoomRepository.removeUserFromChatRoom(userId, roomId);
+    }
+
+    @Override
+    public Set<String> getUsersInRoom(String roomId) {
+        return chatRoomRepository.getUsersInRoom(roomId);
+    }
+
+    @Override
+    public void saveChatMessage(ChatMessage message) {
+        log.info("Saving chat message: {}", message);
+        chatRoomRepository.saveChatMessage(message);
+    }
+
+    @Override
+    public List<ChatMessage> getRoomMessages(String roomId) {
+        return chatRoomRepository.getMessages(roomId);
+    }
+
+    @Override
+    public List<ChatMessage> getRecentMessages(String email) {
+        return chatRoomRepository.getRecentMessages(email);
+    }
+
+    @Override
+    public void processMessage(ChatMessage message) {
+        ChatRoom chatRoom = validateAndGetChatRoom(message.getRoomId(), message.getSender());
+
+        handleEnterMessage(message);
+        publishMessage(message);
+        saveChatMessage(message);
+
+        // ENTER 타입이 아닌 경우에만 알림 생성
+        if (!ChatMessage.MessageType.ENTER.equals(message.getType())) {
+            createMessageNotification(message, chatRoom);
+        }
+    }
+
+    @Override
+    public ChatRoom createOneToOneChatRoom(String currentUserId, String targetUserId, String name) {
+        validateOneToOneChatRequest(currentUserId, targetUserId);
+        log.info("Creating 1:1 chat room between users: {} and {}", currentUserId, targetUserId);
+
+        ChatRoom chatRoom = chatRoomRepository.findOrCreateOneToOneChatRoom(currentUserId, targetUserId, name);
+
+        // 채팅방 생성 알림
+        notificationService.createNotification(
+                targetUserId,
+                String.format("%s님이 1:1 채팅을 시작했습니다.", currentUserId),
+                "/chat/room/" + chatRoom.getRoomId(),
+                Notification.NotificationType.CHAT_ROOM_INVITE
+        );
+
+        return chatRoom;
+    }
+
+    @Override
+    public void enterChatRoom(String roomId) {
+        log.info("User entering chat room: {}", roomId);
+        chatRoomRepository.enterChatRoom(roomId);
+    }
+
+    @Override
+    public ChannelTopic getTopic(String roomId) {
+        return chatRoomRepository.getTopic(roomId);
+    }
+
+    private ChatRoom validateAndGetChatRoom(String roomId, String userId) {
+        ChatRoom room = chatRoomRepository.findRoomById(roomId);
+        if (room == null) {
+            throw new IllegalArgumentException("Chat room not found");
+        }
+
+        if (room.isOneToOne() && !room.isValidOneToOneParticipant(userId)) {
+            throw new IllegalArgumentException("User not authorized for this chat room");
+        }
+
+        return room;
+    }
+
+    private void validateOneToOneChatRequest(String currentUserId, String targetUserId) {
+        if (currentUserId.equals(targetUserId)) {
+            throw new IllegalArgumentException("Cannot create chat room with yourself");
+        }
+    }
+
+    private void handleEnterMessage(ChatMessage message) {
+        if (ChatMessage.MessageType.ENTER.equals(message.getType())) {
+            chatRoomRepository.enterChatRoom(message.getRoomId());
+            message.setMessage(message.getSender() + "님이 입장하셨습니다.");
+        }
+    }
+
+    private void publishMessage(ChatMessage message) {
+        redisPublisher.publish(chatRoomRepository.getTopic(message.getRoomId()), message);
+    }
+
+    private void createMessageNotification(ChatMessage message, ChatRoom chatRoom) {
+        chatRoom.getParticipants().stream()
+                .filter(participantId -> !participantId.equals(message.getSender()))
+                .forEach(recipientId -> {
+                    try {
+                        // 읽지 않은 기존 알림들 찾기
+                        List<Notification> existingNotifications =
+                                notificationRepository.findUnreadByMemberEmailAndRoomIdAndType(
+                                        recipientId,
+                                        message.getRoomId(),
+                                        Notification.NotificationType.CHAT_MESSAGE
+                                );
+
+                        if (!existingNotifications.isEmpty()) {
+                            // 가장 최근 알림만 업데이트하고 나머지는 삭제
+                            Notification latestNotification = existingNotifications.get(0);
+                            updateExistingNotification(latestNotification, message, chatRoom);
+
+                            // 첫 번째를 제외한 나머지 알림들 삭제
+                            if (existingNotifications.size() > 1) {
+                                notificationRepository.deleteAll(
+                                        existingNotifications.subList(1, existingNotifications.size())
+                                );
+                            }
+                        } else {
+                            // 새 알림 생성
+                            createNewChatNotification(recipientId, message, chatRoom);
+                        }
+                    } catch (Exception e) {
+                        log.error("Failed to handle notification: {}", e.getMessage());
+                    }
+                });
+    }
+
+    private void updateExistingNotification(Notification notification,
+                                            ChatMessage message,
+                                            ChatRoom chatRoom) {
+        String notificationContent = createNotificationContent(message, chatRoom);
+        notification.updateContent(notificationContent);
+        notificationRepository.save(notification);
+    }
+
+    private void createNewChatNotification(String recipientId,
+                                           ChatMessage message,
+                                           ChatRoom chatRoom) {
+        Member recipient = memberRepository.findById(recipientId)
+                .orElseThrow(() -> new RuntimeException("Member not found"));
+
+        Notification notification = Notification.builder()
+                .member(recipient)
+                .content(createNotificationContent(message, chatRoom))
+                .link("/chat/room/" + chatRoom.getRoomId())
+                .isRead(false)
+                .createdAt(LocalDateTime.now())
+                .roomId(chatRoom.getRoomId())  // roomId 설정
+                .type(Notification.NotificationType.CHAT_MESSAGE)
+                .build();
+
+        notificationRepository.save(notification);
+    }
+
+    private String createNotificationContent(ChatMessage message, ChatRoom chatRoom) {
+        if (chatRoom.isOneToOne()) {
+            return String.format("%s로부터 새 메시지가 도착했습니다.", message.getSender());
+        }
+        return String.format("[%s] 새 메시지가 도착했습니다.", chatRoom.getName());
+    }
+}

--- a/src/main/java/com/danum/danum/service/notification/NotificationService.java
+++ b/src/main/java/com/danum/danum/service/notification/NotificationService.java
@@ -6,6 +6,7 @@ import com.danum.danum.domain.member.Member;
 import com.danum.danum.repository.notification.NotificationRepository;
 import com.danum.danum.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,6 +14,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class NotificationService {
@@ -35,6 +37,7 @@ public class NotificationService {
                 .build();
 
         notificationRepository.save(notification);
+        log.info("Notification created: {}", notification.getId());
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
이전 채팅로직의 문제점은
- ChatRoomRepository에 과도한 책임 집중
- 컨트롤러에서 직접 Repository 접근
- 순환 참조로 인한 구조적 문제
- 채팅 알림의 중복 발생

---

1. 채팅 서비스 구조 개선
- ChatRoomRepository에 집중되어 있던 비즈니스 로직을 서비스 계층으로 이동
- 인터페이스와 구현체로 분리하여 의존성 역전 원칙(DIP) 적용
  - ChatService 인터페이스 생성
  - ChatServiceImpl 구현체로 비즈니스 로직 이동
- Repository와 Service 계층의 명확한 책임 분리로 순환 참조 문제 해결

2. 채팅 알림 기능 추가
- 알림 발생 조건 구현
  - 1:1 채팅방 생성 시 초대 알림
  - 채팅 메시지 수신 시 알림
- 채팅방별 알림 최적화
  - roomId 필드 추가로 채팅방별 알림 관리
  - 읽지 않은 알림 중복 방지 로직 구현
  - 채팅방당 최신 알림만 유지하도록 개선

3. 코드 품질 개선
- 메서드 분리를 통한 단일 책임 원칙(SRP) 준수
- 예외 처리 강화 및 로깅 추가
- 불필요한 if-else문과 삼항 연산자 제거
- Optional을 활용한 null 처리 개선

4. 성능 최적화
- 채팅방별 알림 조회를 위한 인덱스 추가
- 중복 알림 제거로 데이터베이스 부하 감소
- 메시지 처리 로직 최적화