### PR TITLE
refactor: 질문게시판 로직 리팩토링

### DIFF
--- a/src/main/java/com/danum/danum/service/board/village/VillageServiceImpl.java
+++ b/src/main/java/com/danum/danum/service/board/village/VillageServiceImpl.java
@@ -1,7 +1,6 @@
 package com.danum.danum.service.board.village;
 
-import com.danum.danum.domain.board.question.Question;
-import com.danum.danum.domain.board.question.QuestionLike;
+
 import com.danum.danum.domain.board.village.*;
 import com.danum.danum.domain.member.Member;
 import com.danum.danum.exception.custom.BoardException;
@@ -18,159 +17,177 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-public class VillageServiceImpl implements VillageService{
+public class VillageServiceImpl implements VillageService {
 
     private final VillageRepository villageRepository;
-
     private final VillageMapper villageMapper;
-
     private final VillageEmailRepository villageEmailRepository;
-
     private final VillageLikeRepository villageLikeRepository;
-
     private final MemberRepository memberRepository;
-
     private final VillageCommentRepository villageCommentRepository;
-
     private final AddressParser addressParser;
 
     @Override
     @Transactional
     public void create(VillageNewDto villageNewDto) {
-        if (villageNewDto.getEmail().isEmpty()) {
-            throw new MemberException(ErrorCode.MEMBER_NOT_FOUND_EXCEPTION);
-        }
+        validateMemberExists(villageNewDto.getEmail());
         Village village = villageMapper.toEntity(villageNewDto);
-
         villageRepository.save(village);
     }
 
     @Override
     @Transactional(readOnly = true)
     public Page<VillageViewDto> viewList(Pageable pageable) {
-        Page<Village> villagePage = villageRepository.findAll(pageable);
-        return villagePage.map(village -> new VillageViewDto().toEntity(village));
+        return villageRepository.findAll(pageable)
+                .map(this::convertToViewDto);
     }
 
     @Override
     @Transactional
     public VillageViewDto view(Long id, String email) {
-        Village village = villageRepository.findById(id)
-                .orElseThrow(() -> new BoardException(ErrorCode.BOARD_NOT_FOUND_EXCEPTION));
-        viewCheck(village, email);
-        return new VillageViewDto().toEntity(village);
-    }
-
-    private void viewCheck(Village village, String email) {
-        Optional<VillageEmailToken> optionalVillageEmailToken = villageEmailRepository.findById(village.getId());
-        if (optionalVillageEmailToken.isPresent() && optionalVillageEmailToken.get().getEmail().equals(email)) {
-            return;
-        }
-
-        VillageEmailToken token = VillageEmailToken.builder()
-                .id(village.getId())
-                .email(email)
-                .build();
-        village.increasedViews();
-
-        villageRepository.save(village);
-        villageEmailRepository.save(token);
+        Village village = findVillageById(id);
+        processViewCount(village, email);
+        return convertToViewDto(village);
     }
 
     @Override
+    @Transactional
     public void likeStatus(Long id, String email) {
-        Village village = villageRepository.findById(id)
-                .orElseThrow(() -> new BoardException(ErrorCode.BOARD_NOT_FOUND_EXCEPTION));
-        Member member = memberRepository.findById(email)
-                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND_EXCEPTION));
-
-        Optional<VillageLike> optionalVillageLike = villageLikeRepository.findByVillageIdAndMemberEmail(village, member);
-
-        if (optionalVillageLike.isPresent()) {
-            village.subLike();
-            villageLikeRepository.delete(optionalVillageLike.get());
-            villageRepository.save(village);
-            return;
-        }
-
-        VillageLike villageLike = VillageLike.builder()
-                .villageId(village)
-                .memberEmail(member)
-                .build();
-        village.addLike();
-        villageLikeRepository.save(villageLike);
-        villageRepository.save(village);
-    }
-
-    private VillageViewDto convertToViewDto(Village village) {
-        return new VillageViewDto().toEntity(village);
+        Village village = findVillageById(id);
+        Member member = findMemberByEmail(email);
+        processLikeStatus(village, member);
     }
 
     @Override
     @Transactional
     public void deleteVillage(Long id) {
-        Village village = villageRepository.findById(id)
-                .orElseThrow(() -> new BoardException(ErrorCode.BOARD_NOT_FOUND_EXCEPTION));
+        Village village = findVillageById(id);
         villageRepository.delete(village);
     }
 
+    @Override
+    @Transactional
     public void update(VillageUpdateDto villageUpdateDto, String loginUser) {
-        Village village = villageRepository.findById(villageUpdateDto.getId())
-                .orElseThrow(() -> new BoardException(ErrorCode.BOARD_NOT_FOUND_EXCEPTION));
-        userCheck(village.getMember().getEmail(), loginUser);
-        village.update(villageUpdateDto.getContent(), villageUpdateDto.getTitle());
-
-        villageRepository.save(village);
-    }
-
-    public void userCheck(String author, String loginUser) {
-        if (!author.equals(loginUser)) {
-            throw new CommentException(ErrorCode.COMMENT_NOT_AUTHOR_EXCEPTION);
-        }
+        Village village = findVillageById(villageUpdateDto.getId());
+        validateAuthor(village.getMember().getEmail(), loginUser);
+        updateVillageContent(village, villageUpdateDto);
     }
 
     @Override
     public List<VillageViewDto> getPopularVillages(int limit) {
         return villageRepository.findPopularVillages(PageRequest.of(0, limit))
                 .stream()
-                .map(village -> new VillageViewDto().toEntity(village))
+                .map(this::convertToViewDto)
                 .collect(Collectors.toList());
     }
 
     @Override
     @Transactional(readOnly = true)
     public Page<VillageViewDto> getVillagesByPostType(VillagePostType postType, Pageable pageable) {
-        Page<Village> villagePage = villageRepository.findByPostType(postType, pageable);
-        return villagePage.map(this::convertToViewDto);
+        return villageRepository.findByPostType(postType, pageable)
+                .map(this::convertToViewDto);
     }
 
     @Override
     @Transactional(readOnly = true)
     public boolean hasAcceptedComment(Long villageId) {
-        return villageCommentRepository.existsByVillageAndIsAcceptedTrue(villageRepository.findById(villageId)
-                .orElseThrow(() -> new BoardException(ErrorCode.BOARD_NOT_FOUND_EXCEPTION)));
+        Village village = findVillageById(villageId);
+        return villageCommentRepository.existsByVillageAndIsAcceptedTrue(village);
     }
 
     @Override
     @Transactional(readOnly = true)
     public Page<VillageViewDto> getLocalVillages(String userEmail, Pageable pageable) {
-        Member member = memberRepository.findById(userEmail)
-                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND_EXCEPTION));
+        Member member = findMemberByEmail(userEmail);
         String userAddressTag = AddressParser.parseAddress(member.getAddress());
+        return villageRepository.findByAddressTagStartingWith(userAddressTag, pageable)
+                .map(this::convertToViewDto);
+    }
 
-        Page<Village> localVillages = villageRepository.findByAddressTagStartingWith(userAddressTag, pageable);
-        return localVillages.map(this::convertToViewDto);
+    private void validateMemberExists(String email) {
+        if (email.isEmpty()) {
+            throw new MemberException(ErrorCode.MEMBER_NOT_FOUND_EXCEPTION);
+        }
+    }
+
+    private Village findVillageById(Long id) {
+        return villageRepository.findById(id)
+                .orElseThrow(() -> new BoardException(ErrorCode.BOARD_NOT_FOUND_EXCEPTION));
+    }
+
+    private Member findMemberByEmail(String email) {
+        return memberRepository.findById(email)
+                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND_EXCEPTION));
+    }
+
+    private void processViewCount(Village village, String email) {
+        boolean hasAlreadyViewed = villageEmailRepository.findById(village.getId())
+                .map(token -> token.getEmail().equals(email))
+                .orElse(false);
+
+        if (!hasAlreadyViewed) {
+            saveNewView(village, email);
+        }
+    }
+
+    private void saveNewView(Village village, String email) {
+        VillageEmailToken token = VillageEmailToken.builder()
+                .id(village.getId())
+                .email(email)
+                .build();
+
+        village.increasedViews();
+        villageRepository.save(village);
+        villageEmailRepository.save(token);
+    }
+
+    private void processLikeStatus(Village village, Member member) {
+        Optional<VillageLike> existingLike = villageLikeRepository.findByVillageIdAndMemberEmail(village, member);
+
+        existingLike.ifPresentOrElse(
+                like -> removeLike(village, like),
+                () -> addLike(village, member)
+        );
+    }
+
+    private void removeLike(Village village, VillageLike like) {
+        village.subLike();
+        villageLikeRepository.delete(like);
+        villageRepository.save(village);
+    }
+
+    private void addLike(Village village, Member member) {
+        VillageLike villageLike = VillageLike.builder()
+                .villageId(village)
+                .memberEmail(member)
+                .build();
+
+        village.addLike();
+        villageLikeRepository.save(villageLike);
+        villageRepository.save(village);
+    }
+
+    private void validateAuthor(String author, String loginUser) {
+        if (!author.equals(loginUser)) {
+            throw new CommentException(ErrorCode.COMMENT_NOT_AUTHOR_EXCEPTION);
+        }
+    }
+
+    private void updateVillageContent(Village village, VillageUpdateDto updateDto) {
+        village.update(updateDto.getContent(), updateDto.getTitle());
+        villageRepository.save(village);
+    }
+
+    private VillageViewDto convertToViewDto(Village village) {
+        return new VillageViewDto().toEntity(village);
     }
 }


### PR DESCRIPTION
## 왜 변경하셨나요 ?
> 반복적으로 사용되는 엔티티 조회 로직인 findVillageById, findMemberByEmail 메소드로 추출하여 재사용성 및 성능최적화
> 메소드 분리 및 책임 명확화를 위해 메소드 단위로 분리하여,
> 단일 책임 원칙, 코드 재사용성, 에러 처리 일관성, 성능 최적화를 중점으로 리팩토링하였습니다.

## 변경 사항

### 1. 메소드 분리 및 책임 명확화
- viewCheck 메소드를 processViewCount와 saveNewView로 분리
- likeStatus 메소드의 좋아요 처리 로직을 processLikeStatus로 분리
- 반복되는 엔티티 조회 로직을 findVillageById, findMemberByEmail 메소드로 추출

### 2. Optional 활용 개선
- if-else 구문을 Optional의 ifPresentOrElse로 대체하여 좋아요 처리 로직 개선
- null 체크 로직을 Optional을 활용하여 안전하게 처리

### 3. 메소드 네이밍 개선
- viewCheck → processViewCount
- userCheck → validateAuthor 
등 메소드의 역할을 더 명확하게 표현하는 이름으로 변경

### 4. 트랜잭션 범위 최적화
- 읽기 전용 메소드에 @Transactional(readOnly = true) 적용