### PR TITLE
feat: 사용자 정보 반환 api 및 프로필 이미지 로직 수정

### DIFF
--- a/src/main/java/com/danum/danum/controller/MemberController.java
+++ b/src/main/java/com/danum/danum/controller/MemberController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @RestController
@@ -25,6 +26,12 @@ public class MemberController {
     @PostMapping("/join")
     public ResponseEntity<?> register(@RequestBody RegisterDto registerDto) {
         Member member = memberService.join(registerDto);
+        return ResponseEntity.ok(member);
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<Member> getMyInfo(Authentication authentication) {
+        Member member = memberService.getMemberByAuthentication();
         return ResponseEntity.ok(member);
     }
 
@@ -46,12 +53,14 @@ public class MemberController {
         return ResponseEntity.ok("회원탈퇴에 성공하였습니다.");
     }
 
-
     @GetMapping("/profile-image")
     public ResponseEntity<String> getProfileImage(Authentication authentication) {
-        String email = authentication.getName();
-        String profileImageUrl = memberService.getProfileImageUrl(email);
-        return ResponseEntity.ok(profileImageUrl);
+        return ResponseEntity.ok(
+                Optional.ofNullable(authentication)
+                        .map(Authentication::getName)
+                        .map(memberService::getProfileImageUrl)
+                        .orElse(null)
+        );
     }
 
     @PreAuthorize("hasRole('ADMIN')")

--- a/src/main/java/com/danum/danum/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/danum/danum/service/member/MemberServiceImpl.java
@@ -206,9 +206,9 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public String getProfileImageUrl(String email) {
-        Member member = memberRepository.findById(email)
+        return memberRepository.findById(email)
+                .map(Member::getProfileImageUrl)
                 .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND_EXCEPTION));
-        return member.getProfileImageUrl();
     }
 
     @Override


### PR DESCRIPTION
- 사용자의 마이페이지를 구성하기위해 Authentication을 통해 인증된 사용자일때 해당 사용자의 정보를 반환하는 API 추가

- MemberController 에서 getProfileImage의 메소드는 사용자의 프로필사진을 가져오는 로직에서 
기본적으로 사용자 프로필사진가 없을시 프론트에서 기본이미지를 넣도록 반영된걸 가지고
인증되지않은 사용자의 경우 null을 반환하여 프론트엔드에서 기본 이미지처리를 하도록 설정하였고,
인증된 사용자의 경우 해당 사용자의 프로필 이미지 URL을 반환하도록 설정하였음