### PR TITLE
refactor: 회원정보 업데이트 로직 개선

### DIFF
--- a/src/main/java/com/danum/danum/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/danum/danum/service/member/MemberServiceImpl.java
@@ -83,15 +83,11 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public Member update(UpdateDto updateDto) {
-        validateDuplicatedName(updateDto.getName());
-
         String memberEmail = updateDto.getEmail();
         Optional<Member> optionalMember = memberRepository.findById(memberEmail);
-        optionalMember.orElseThrow(() ->
+        Member member = optionalMember.orElseThrow(() ->
                 new MemberException(ErrorCode.MEMBER_NOT_FOUND_EXCEPTION)
         );
-
-        Member member = optionalMember.get();
 
         String changePassword = updateDto.getPassword();
         String changePhone = updateDto.getPhone();
@@ -101,6 +97,12 @@ public class MemberServiceImpl implements MemberService {
         Double changeLongitude = updateDto.getLongitude();
         String changeAddress = updateDto.getAddress();
 
+        // 이름이 변경되었을 때만 중복 검사 수행
+        if (StringUtils.hasText(changeName) && !changeName.equals(member.getName())) {
+            validateDuplicatedName(changeName);
+            member.updateUserName(changeName);
+        }
+
         if (StringUtils.hasText(changePassword)) {
             member.updateUserPassword(
                     passwordEncoder.encode(changePassword));
@@ -108,10 +110,7 @@ public class MemberServiceImpl implements MemberService {
         if (StringUtils.hasText(changePhone)) {
             member.updateUserPhone(changePhone);
         }
-        if (StringUtils.hasText(changeName)) {
-            member.updateUserName(changeName);
-        }
-        if (StringUtils.hasText(changeProfileImageUrl)) {  // 추가
+        if (StringUtils.hasText(changeProfileImageUrl)) {
             member.updateProfileImageUrl(changeProfileImageUrl);
         }
         if (changeLatitude != null && changeLongitude != null) {


### PR DESCRIPTION
- 이름 중복 검사 로직 변경
 - 기존: 모든 업데이트 요청에서 이름 중복 검사 수행
 - 변경: 이름 변경 시에만 중복 검사 수행

- 사용자 편의성 개선
 - 이름을 현재 값과 동일하게 유지하면서 다른 정보만 수정 가능
 - 각 필드별 독립적인 업데이트 가능