### PR TITLE
refactor: getRecentChats API의 반환개수 조정

### DIFF
--- a/src/main/java/com/danum/danum/controller/board/MainPageController.java
+++ b/src/main/java/com/danum/danum/controller/board/MainPageController.java
@@ -154,7 +154,7 @@ public class MainPageController {
     @GetMapping("/recent-chats")
     public ResponseEntity<List<RecentChatDto>> getRecentChats(Authentication authentication) {
         String userEmail = authentication.getName();
-        List<RecentChatDto> recentChats = chatService.getRecentChatsForUser(userEmail, 5);
+        List<RecentChatDto> recentChats = chatService.getRecentChatsForUser(userEmail, 10);
         return ResponseEntity.ok(recentChats);
     }
 }


### PR DESCRIPTION
기존에는 채팅 내역을 5개를 뿌려줬던것을 10개로 조정하였습니다.