### PR TITLE
refactor: 회원정보 수정 시 현재 인증된 사용자정보를 사용하도록 수정

### DIFF
--- a/src/main/java/com/danum/danum/domain/member/UpdateDto.java
+++ b/src/main/java/com/danum/danum/domain/member/UpdateDto.java
@@ -7,8 +7,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class UpdateDto {
 
-    private String email;
-
     private String password;
 
     private String phone;

--- a/src/main/java/com/danum/danum/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/danum/danum/service/member/MemberServiceImpl.java
@@ -83,11 +83,7 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public Member update(UpdateDto updateDto) {
-        String memberEmail = updateDto.getEmail();
-        Optional<Member> optionalMember = memberRepository.findById(memberEmail);
-        Member member = optionalMember.orElseThrow(() ->
-                new MemberException(ErrorCode.MEMBER_NOT_FOUND_EXCEPTION)
-        );
+        Member member = getMemberByAuthentication();
 
         String changePassword = updateDto.getPassword();
         String changePhone = updateDto.getPhone();
@@ -97,7 +93,11 @@ public class MemberServiceImpl implements MemberService {
         Double changeLongitude = updateDto.getLongitude();
         String changeAddress = updateDto.getAddress();
 
-        // 이름이 변경되었을 때만 중복 검사 수행
+        if (StringUtils.hasText(changeName) && !changeName.equals(member.getName())) {
+            validateDuplicatedName(changeName);
+            member.updateUserName(changeName);
+        }
+
         if (StringUtils.hasText(changeName) && !changeName.equals(member.getName())) {
             validateDuplicatedName(changeName);
             member.updateUserName(changeName);


### PR DESCRIPTION
불필요한 email 필드 제거
보안 강화를 위해 SecurityContext에서 현재 사용자 정보를 가져오도록 수정
ID null 에러 해결