### PR TITLE
fix: 사용자 프로필이 없을시 null값으로 처리

### DIFF
--- a/src/main/java/com/danum/danum/service/chat/ChatServiceImpl.java
+++ b/src/main/java/com/danum/danum/service/chat/ChatServiceImpl.java
@@ -297,7 +297,9 @@ public class ChatServiceImpl implements ChatService {
                         .map(partner -> ChatPartnerInfo.builder()
                                 .email(partner.getEmail())
                                 .name(partner.getName())
-                                .profileImageUrl(partner.getProfileImageUrl())
+                                .profileImageUrl(Optional.ofNullable(partner.getProfileImageUrl())
+                                        .filter(url -> !url.isEmpty())
+                                        .orElse(null))
                                 .build())
                         .orElse(ChatPartnerInfo.empty()))
                 .orElse(ChatPartnerInfo.empty());


### PR DESCRIPTION
최근 채팅내역을 가져오는 로직에서 자신이나 상대방의 프로필사진이 없더라도 프론트엔드에서 지정된 기본이미지값을 사용할수있도록 프로필이미지가 없는사용자는 null값으로 처리